### PR TITLE
added example for testing protocols that extend AnyObservableObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ formatting guidelines.
 
 ### Added
 
+- Examples for testing `AnyObservableObject` in both example projects.
 - Added automated tests.
 - Created a changelog, contributing guidelines, and issue templates.
 

--- a/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
+++ b/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
@@ -11,12 +11,17 @@
 		607FACD81AFB9204008FA782 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ContentView.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		607FACEC1AFB9204008FA782 /* PrimaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* PrimaryViewModelTests.swift */; };
+		632E2F002829A35C0017290D /* SecondaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104E282990FC00526130 /* SecondaryViewModelTests.swift */; };
+		634A104528298F3300526130 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104428298F3300526130 /* Models.swift */; };
+		634A104728298F5D00526130 /* PrimaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104628298F5D00526130 /* PrimaryView.swift */; };
+		634A104928298F7900526130 /* SecondaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104828298F7900526130 /* SecondaryView.swift */; };
+		634A104D28298FEB00526130 /* SecondaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104C28298FEB00526130 /* SecondaryViewModel.swift */; };
 		BA6DA14DD50DE39EFA5C15FE /* Pods_Dependiject_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45DAEA3ADB333F03E46E552F /* Pods_Dependiject_Example.framework */; };
 		EC4928BD2805F023004E11C6 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4928BC2805F023004E11C6 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift */; };
 		EC529AEC27FB2B610044EF7A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC529AEB27FB2B610044EF7A /* AppDelegate.swift */; };
 		EC7E744C27FC81B200E38C67 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7E744B27FC81B200E38C67 /* SceneDelegate.swift */; };
-		ECD5DF8527FDFF7E00DFEA5D /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD5DF8427FDFF7E00DFEA5D /* ContentViewModel.swift */; };
+		ECD5DF8527FDFF7E00DFEA5D /* PrimaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD5DF8427FDFF7E00DFEA5D /* PrimaryViewModel.swift */; };
 		ECD5DF8727FE116700DFEA5D /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD5DF8627FE116700DFEA5D /* Services.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,7 +46,12 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* Dependiject_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Dependiject_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		607FACEB1AFB9204008FA782 /* PrimaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryViewModelTests.swift; sourceTree = "<group>"; };
+		634A104428298F3300526130 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		634A104628298F5D00526130 /* PrimaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryView.swift; sourceTree = "<group>"; };
+		634A104828298F7900526130 /* SecondaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryView.swift; sourceTree = "<group>"; };
+		634A104C28298FEB00526130 /* SecondaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryViewModel.swift; sourceTree = "<group>"; };
+		634A104E282990FC00526130 /* SecondaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryViewModelTests.swift; sourceTree = "<group>"; };
 		6D7749DA867EB7D83741BEF1 /* Pods-Dependiject_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dependiject_Example.release.xcconfig"; path = "Target Support Files/Pods-Dependiject_Example/Pods-Dependiject_Example.release.xcconfig"; sourceTree = "<group>"; };
 		85270969A9C710B3BD0CDB97 /* Pods-swiftdi_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftdi_Tests.debug.xcconfig"; path = "Target Support Files/Pods-swiftdi_Tests/Pods-swiftdi_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		89F1E5CA24D8E675AAB60143 /* Pods-Dependiject_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dependiject_Tests.debug.xcconfig"; path = "Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -52,7 +62,7 @@
 		EC4928BC2805F023004E11C6 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Dependiject_Tests-Dependiject_ExampleMocks.generated.swift"; path = "MockingbirdMocks/Dependiject_Tests-Dependiject_ExampleMocks.generated.swift"; sourceTree = "<group>"; };
 		EC529AEB27FB2B610044EF7A /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EC7E744B27FC81B200E38C67 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = Dependiject/SceneDelegate.swift; sourceTree = SOURCE_ROOT; };
-		ECD5DF8427FDFF7E00DFEA5D /* ContentViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
+		ECD5DF8427FDFF7E00DFEA5D /* PrimaryViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryViewModel.swift; sourceTree = "<group>"; };
 		ECD5DF8627FE116700DFEA5D /* Services.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -112,11 +122,15 @@
 				EC529AEB27FB2B610044EF7A /* AppDelegate.swift */,
 				607FACD71AFB9204008FA782 /* ContentView.swift */,
 				EC7E744B27FC81B200E38C67 /* SceneDelegate.swift */,
-				ECD5DF8427FDFF7E00DFEA5D /* ContentViewModel.swift */,
+				ECD5DF8427FDFF7E00DFEA5D /* PrimaryViewModel.swift */,
 				ECD5DF8627FE116700DFEA5D /* Services.swift */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
 				607FACD41AFB9204008FA782 /* Info.plist */,
+				634A104428298F3300526130 /* Models.swift */,
+				634A104628298F5D00526130 /* PrimaryView.swift */,
+				634A104828298F7900526130 /* SecondaryView.swift */,
+				634A104C28298FEB00526130 /* SecondaryViewModel.swift */,
 			);
 			path = Dependiject;
 			sourceTree = "<group>";
@@ -124,7 +138,8 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				607FACEB1AFB9204008FA782 /* Tests.swift */,
+				607FACEB1AFB9204008FA782 /* PrimaryViewModelTests.swift */,
+				634A104E282990FC00526130 /* SecondaryViewModelTests.swift */,
 				607FACEA1AFB9204008FA782 /* Info.plist */,
 			);
 			path = Tests;
@@ -363,9 +378,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC529AEC27FB2B610044EF7A /* AppDelegate.swift in Sources */,
+				634A104928298F7900526130 /* SecondaryView.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ContentView.swift in Sources */,
 				EC7E744C27FC81B200E38C67 /* SceneDelegate.swift in Sources */,
-				ECD5DF8527FDFF7E00DFEA5D /* ContentViewModel.swift in Sources */,
+				634A104D28298FEB00526130 /* SecondaryViewModel.swift in Sources */,
+				634A104528298F3300526130 /* Models.swift in Sources */,
+				634A104728298F5D00526130 /* PrimaryView.swift in Sources */,
+				ECD5DF8527FDFF7E00DFEA5D /* PrimaryViewModel.swift in Sources */,
 				ECD5DF8727FE116700DFEA5D /* Services.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -375,7 +394,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC4928BD2805F023004E11C6 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift in Sources */,
-				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
+				607FACEC1AFB9204008FA782 /* PrimaryViewModelTests.swift in Sources */,
+				632E2F002829A35C0017290D /* SecondaryViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS 13 Example/Dependiject/AppDelegate.swift
+++ b/iOS 13 Example/Dependiject/AppDelegate.swift
@@ -59,10 +59,21 @@ extension AppDelegate {
                 DataValidatorImplementation()
             }
             
-            Service(.weak, ContentViewModel.self) { r in
-                ContentViewModelImplementation(
+            MultitypeService(exposedAs: [DataStateUpdater.self, DataStateAccessor.self]) { r in
+                DataStateManagerImplementation()
+            }
+            
+            Service(.weak, PrimaryViewModel.self) { r in
+                PrimaryViewModelImplementation(
                     fetcher: r.resolve(),
-                    validator: r.resolve()
+                    validator: r.resolve(),
+                    updater: r.resolve()
+                )
+            }
+            
+            Service(.weak, SecondaryViewModel.self) { r in
+                SecondaryViewModelImplementation(
+                    updater: r.resolve()
                 )
             }
         }

--- a/iOS 13 Example/Dependiject/ContentView.swift
+++ b/iOS 13 Example/Dependiject/ContentView.swift
@@ -10,31 +10,14 @@ import SwiftUI
 import Dependiject
 
 struct ContentView: View {
-    @Store var viewModel = Factory.shared.resolve(ContentViewModel.self)
+    @Store var dataStateAccessor = Factory.shared.resolve(DataStateAccessor.self)
     
     var body: some View {
-        VStack(spacing: 0) {
-            Button("Fetch new data") {
-                Task {
-                    await viewModel.refreshData()
-                }
-            }
-            .padding()
-            
-            Divider()
-            
-            List(viewModel.array, id: \.self) {
-                Text("\($0)")
-            }
-            .listStyle(.grouped)
+        switch dataStateAccessor.dataState {
+        case .unconfirmed:
+            PrimaryView()
+        case .confirmed:
+            SecondaryView()
         }
-    }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView(
-            viewModel: ContentViewModelMock()
-        )
     }
 }

--- a/iOS 13 Example/Dependiject/Models.swift
+++ b/iOS 13 Example/Dependiject/Models.swift
@@ -1,0 +1,12 @@
+//
+//  Models.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+enum DataState {
+    case unconfirmed
+    case confirmed
+}

--- a/iOS 13 Example/Dependiject/PrimaryView.swift
+++ b/iOS 13 Example/Dependiject/PrimaryView.swift
@@ -1,0 +1,42 @@
+//
+//  PrimaryView.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import SwiftUI
+import Dependiject
+
+struct PrimaryView: View {
+    @Store var viewModel = Factory.shared.resolve(PrimaryViewModel.self)
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Button("Fetch new data") {
+                Task {
+                    await viewModel.refreshData()
+                }
+            }
+            .padding()
+            
+            Divider()
+            
+            List(viewModel.array, id: \.self) {
+                Text("\($0)")
+            }
+            .listStyle(.grouped)
+            
+            Button("Confirm Data") {
+                viewModel.confirmData()
+            }
+        }
+    }
+}
+
+struct PrimaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        PrimaryView()
+    }
+}

--- a/iOS 13 Example/Dependiject/PrimaryViewModel.swift
+++ b/iOS 13 Example/Dependiject/PrimaryViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ContentViewModel.swift
+//  PrimaryViewModel.swift
 //  Dependiject_Example
 //
 //  Created by William Baker on 04/06/2022.
@@ -8,22 +8,30 @@
 
 import Dependiject
 
-protocol ContentViewModel: AnyObservableObject {
+protocol PrimaryViewModel: AnyObservableObject {
     /// A list of things to display.
     var array: [Int] { get }
     /// Update the array.
     func refreshData() async
+    /// Confirms data, updates global state
+    func confirmData()
 }
 
-final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
+final class PrimaryViewModelImplementation: PrimaryViewModel, ObservableObject {
     @Published var array: [Int] = []
     
     private let fetcher: DataFetcher
     private let validator: DataValidator
+    private let dataStateUpdater: DataStateUpdater
     
-    init(fetcher: DataFetcher, validator: DataValidator) {
+    init(
+        fetcher: DataFetcher,
+        validator: DataValidator,
+        updater: DataStateUpdater
+    ) {
         self.fetcher = fetcher
         self.validator = validator
+        self.dataStateUpdater = updater
     }
     
     func refreshData() async {
@@ -31,12 +39,8 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
         let filteredData = validator.pickValidItems(from: rawData)
         self.array = filteredData
     }
-}
-
-final class ContentViewModelMock: ContentViewModel, ObservableObject {
-    @Published var array: [Int] = [2, 4, 6, 8]
     
-    func refreshData() async {
-        // no-op
+    func confirmData() {
+        dataStateUpdater.setDataState(confirmed: true)
     }
 }

--- a/iOS 13 Example/Dependiject/SecondaryView.swift
+++ b/iOS 13 Example/Dependiject/SecondaryView.swift
@@ -1,0 +1,28 @@
+//
+//  SecondaryView.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import SwiftUI
+import Dependiject
+
+struct SecondaryView: View {
+    var viewModel = Factory.shared.resolve(SecondaryViewModel.self)
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Button("Reset Data") {
+                viewModel.resetData()
+            }
+        }
+    }
+}
+
+struct SecondaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        SecondaryView()
+    }
+}

--- a/iOS 13 Example/Dependiject/SecondaryViewModel.swift
+++ b/iOS 13 Example/Dependiject/SecondaryViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  SecondaryViewModel.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import Dependiject
+
+protocol SecondaryViewModel {
+    /// Go back to PrimaryView to edit data, updates global state
+    func resetData()
+}
+
+final class SecondaryViewModelImplementation: SecondaryViewModel {
+    private let dataStateUpdater: DataStateUpdater
+    
+    init(updater: DataStateUpdater) {
+        self.dataStateUpdater = updater
+    }
+    
+    func resetData() {
+        dataStateUpdater.setDataState(confirmed: false)
+    }
+}

--- a/iOS 13 Example/Dependiject/Services.swift
+++ b/iOS 13 Example/Dependiject/Services.swift
@@ -6,6 +6,9 @@
 //  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
 //
 
+import Dependiject
+import Combine
+
 protocol DataFetcher {
     func getData() async -> [Int]
 }
@@ -27,6 +30,32 @@ struct DataValidatorImplementation: DataValidator {
     func pickValidItems(from array: [Int]) -> [Int] {
         return array.filter {
             $0.isMultiple(of: 2)
+        }
+    }
+}
+
+protocol DataStateUpdater {
+    func setDataState(confirmed: Bool)
+}
+
+protocol DataStateAccessor: AnyObservableObject {
+    var dataState: DataState { get }
+}
+
+protocol DataStateManager: DataStateUpdater, DataStateAccessor {}
+
+final class DataStateManagerImplementation: DataStateManager & ObservableObject {
+    @Published var dataState: DataState
+    
+    init() {
+        self.dataState = .unconfirmed
+    }
+    
+    func setDataState(confirmed: Bool) {
+        if confirmed {
+            self.dataState = .confirmed
+        } else {
+            self.dataState = .unconfirmed
         }
     }
 }

--- a/iOS 13 Example/MockingbirdSupport/Combine/ObservableObjectPublisher.swift
+++ b/iOS 13 Example/MockingbirdSupport/Combine/ObservableObjectPublisher.swift
@@ -1,0 +1,84 @@
+//
+//  ObservableObjectPublisher.swift
+//  Dependiject_Tests
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import Swift
+
+public enum Subscribers {
+    public struct Demand : Equatable, Comparable, Hashable, Codable, CustomStringConvertible {
+        public static let unlimited: Subscribers.Demand
+        public static let none: Subscribers.Demand
+        public static func max(_ value: Int) -> Subscribers.Demand
+        public var description: String { get }
+        public static func + (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Subscribers.Demand
+        public static func += (lhs: inout Subscribers.Demand, rhs: Subscribers.Demand)
+        public static func + (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func += (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func * (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func *= (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func - (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Subscribers.Demand
+        public static func -= (lhs: inout Subscribers.Demand, rhs: Subscribers.Demand)
+        public static func - (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func -= (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func > (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func >= (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func > (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func >= (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func < (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func < (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func <= (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func <= (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func < (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func <= (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func >= (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func > (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func == (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func != (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func == (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func != (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public var max: Int? { get }
+        public init(from decoder: Decoder) throws
+        public func encode(to encoder: Encoder) throws
+        public static func == (a: Subscribers.Demand, b: Subscribers.Demand) -> Bool
+        public func hash(into hasher: inout Hasher)
+        public var hashValue: Int { get }
+    }
+    public enum Completion<Failure> where Failure : Error {
+        case finished
+        case failure(Failure)
+    }
+}
+
+public protocol Subscription : Cancellable, CustomCombineIdentifierConvertible {
+    func request(_ demand: Subscribers.Demand)
+}
+
+public protocol Subscriber : CustomCombineIdentifierConvertible {
+    associatedtype Input
+    associatedtype Failure : Error
+    func receive(subscription: Subscription)
+    func receive(_ input: Self.Input) -> Subscribers.Demand
+    func receive(completion: Subscribers.Completion<Self.Failure>)
+}
+
+public protocol Publisher {
+    associatedtype Output
+    associatedtype Failure : Error
+    func receive<S>(subscriber: S)
+    where S : Subscriber, Self.Failure == S.Failure, Self.Output == S.Input
+}
+
+extension Never: Error {}
+
+final public class ObservableObjectPublisher : Publisher {
+    public typealias Output = Void
+    public typealias Failure = Never
+    public init()
+    final public func receive<S>(subscriber: S)
+    where S : Subscriber, S.Failure == Never, S.Input == Void
+    final public func send()
+}

--- a/iOS 13 Example/MockingbirdSupport/Dependiject/AnyObservableObject.swift
+++ b/iOS 13 Example/MockingbirdSupport/Dependiject/AnyObservableObject.swift
@@ -1,0 +1,14 @@
+//
+//  AnyObservableObject.swift
+//  XUI
+//
+//  Created by Paul Kraft on 01.03.21.
+//  Copyright © 2021 QuickBird Studios. All rights reserved.
+//  MIT License
+
+import Swift
+import Combine
+
+public protocol AnyObservableObject: AnyObject {
+    var objectWillChange: ObservableObjectPublisher { get }
+}

--- a/iOS 13 Example/Tests/PrimaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/PrimaryViewModelTests.swift
@@ -60,7 +60,7 @@ class PrimaryViewModelTests: XCTestCase {
         await sut.refreshData()
         
         verify(await mockFetcher.getData()).wasCalled(1)
-        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
+        verify(mockValidator.pickValidItems(from: any())).wasCalled(once)
         
         XCTAssertEqual(sut.array, [1, 2, 3, 4, 5, 6])
     }
@@ -70,6 +70,6 @@ class PrimaryViewModelTests: XCTestCase {
         
         sut.confirmData()
         
-        verify(mockDataStateManager.setDataState(confirmed: true)).wasCalled(1)
+        verify(mockDataStateManager.setDataState(confirmed: true)).wasCalled(once)
     }
 }

--- a/iOS 13 Example/Tests/PrimaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/PrimaryViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  Tests.swift
+//  PrimaryViewModelTests.swift
 //  Dependiject_Tests
 //
 //  Created by William Baker on 03/31/2022.
@@ -11,14 +11,17 @@ import Dependiject
 import Mockingbird
 @testable import Dependiject_Example
 
-class Tests: XCTestCase {
+class PrimaryViewModelTests: XCTestCase {
     var mockFetcher: DataFetcherMock!
     var mockValidator: DataValidatorMock!
-    var sut: ContentViewModel!
+    var mockDataStateManager: DataStateManagerMock!
+    var sut: PrimaryViewModelImplementation!
     
     override func setUp() async throws {
         try await super.setUp()
         
+        mockDataStateManager = mock(DataStateManager.self)
+
         mockFetcher = mock(DataFetcher.self)
         given(await mockFetcher.getData()).willReturn([1, 2, 3, 4, 5, 6])
         
@@ -40,11 +43,16 @@ class Tests: XCTestCase {
             Service(.transient, DataValidator.self) { _ in
                 self.mockValidator
             }
+            
+            MultitypeService(exposedAs: [DataStateAccessor.self, DataStateUpdater.self]) { _ in
+                self.mockDataStateManager
+            }
         }
         
-        sut = ContentViewModelImplementation(
+        sut = PrimaryViewModelImplementation(
             fetcher: Factory.shared.resolve(),
-            validator: Factory.shared.resolve()
+            validator: Factory.shared.resolve(),
+            updater: Factory.shared.resolve()
         )
     }
     
@@ -55,5 +63,13 @@ class Tests: XCTestCase {
         verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
         
         XCTAssertEqual(sut.array, [1, 2, 3, 4, 5, 6])
+    }
+    
+    func testConfirmData() async {
+        await sut.refreshData()
+        
+        sut.confirmData()
+        
+        verify(mockDataStateManager.setDataState(confirmed: true)).wasCalled(1)
     }
 }

--- a/iOS 13 Example/Tests/SecondaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/SecondaryViewModelTests.swift
@@ -1,0 +1,28 @@
+//
+//  SecondaryViewModelTests.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import XCTest
+import Dependiject
+import Mockingbird
+@testable import Dependiject_Example
+
+class SecondaryViewModelTests: XCTestCase {
+    var mockDataStateManager: DataStateManagerMock!
+    var sut: SecondaryViewModelImplementation!
+
+    override func setUp() {
+        super.setUp()
+        mockDataStateManager = mock(DataStateManager.self)
+        sut = SecondaryViewModelImplementation(updater: mockDataStateManager)
+    }
+
+    func testResetData() {
+        sut.resetData()
+        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(1)
+    }
+}

--- a/iOS 13 Example/Tests/SecondaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/SecondaryViewModelTests.swift
@@ -23,6 +23,6 @@ class SecondaryViewModelTests: XCTestCase {
 
     func testResetData() {
         sut.resetData()
-        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(1)
+        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(once)
     }
 }

--- a/iOS 14 Example/Dependiject_Example.xcodeproj/project.pbxproj
+++ b/iOS 14 Example/Dependiject_Example.xcodeproj/project.pbxproj
@@ -8,14 +8,19 @@
 
 /* Begin PBXBuildFile section */
 		01486CF4AC4ED268A6180F04 /* Pods_Dependiject_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25201CCA6173D2A55C17B40F /* Pods_Dependiject_Tests.framework */; };
+		634A103B282974E100526130 /* PrimaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A103A282974E100526130 /* PrimaryView.swift */; };
+		634A103D2829765F00526130 /* SecondaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A103C2829765F00526130 /* SecondaryView.swift */; };
+		634A103F282977EF00526130 /* SecondaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A103E282977EF00526130 /* SecondaryViewModel.swift */; };
+		634A104128298D9A00526130 /* SecondaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104028298D9A00526130 /* SecondaryViewModelTests.swift */; };
+		634A104328298E2B00526130 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634A104228298E2B00526130 /* Models.swift */; };
 		B04E16BE2B8341833E454522 /* Pods_Dependiject_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACF4B530DCD0A8E818DED893 /* Pods_Dependiject_Example.framework */; };
 		EC43EDA02805F1C60063E5B0 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC43ED9F2805F1C60063E5B0 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift */; };
 		EC4C0DDD27FC888100D97DD6 /* Dependiject_ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4C0DDC27FC888100D97DD6 /* Dependiject_ExampleApp.swift */; };
 		EC4C0DDF27FC888100D97DD6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4C0DDE27FC888100D97DD6 /* ContentView.swift */; };
 		EC4C0DE127FC888200D97DD6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EC4C0DE027FC888200D97DD6 /* Assets.xcassets */; };
 		EC4C0DE427FC888200D97DD6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EC4C0DE327FC888200D97DD6 /* Preview Assets.xcassets */; };
-		EC4C0DEE27FC888300D97DD6 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4C0DED27FC888300D97DD6 /* Tests.swift */; };
-		ECCC43322804727E006BED31 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCC43312804727E006BED31 /* ContentViewModel.swift */; };
+		EC4C0DEE27FC888300D97DD6 /* PrimaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4C0DED27FC888300D97DD6 /* PrimaryViewModelTests.swift */; };
+		ECCC43322804727E006BED31 /* PrimaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCC43312804727E006BED31 /* PrimaryViewModel.swift */; };
 		ECCC4334280472B4006BED31 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCC4333280472B4006BED31 /* Services.swift */; };
 /* End PBXBuildFile section */
 
@@ -32,6 +37,11 @@
 /* Begin PBXFileReference section */
 		25201CCA6173D2A55C17B40F /* Pods_Dependiject_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Dependiject_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A64C8AEDCD3B098F9B2D473 /* Pods-swiftdi_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftdi_Example.debug.xcconfig"; path = "Target Support Files/Pods-swiftdi_Example/Pods-swiftdi_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		634A103A282974E100526130 /* PrimaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryView.swift; sourceTree = "<group>"; };
+		634A103C2829765F00526130 /* SecondaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryView.swift; sourceTree = "<group>"; };
+		634A103E282977EF00526130 /* SecondaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryViewModel.swift; sourceTree = "<group>"; };
+		634A104028298D9A00526130 /* SecondaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryViewModelTests.swift; sourceTree = "<group>"; };
+		634A104228298E2B00526130 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		639428914B6FEFDF8FFD03F2 /* Pods-swiftdi_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftdi_Example.release.xcconfig"; path = "Target Support Files/Pods-swiftdi_Example/Pods-swiftdi_Example.release.xcconfig"; sourceTree = "<group>"; };
 		662439428C62CE3C428DEFDE /* Pods-Dependiject_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dependiject_Tests.debug.xcconfig"; path = "Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6E353DD13C19DC9678C5F51A /* Pods-swiftdi_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftdi_Tests.release.xcconfig"; path = "Target Support Files/Pods-swiftdi_Tests/Pods-swiftdi_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -46,8 +56,8 @@
 		EC4C0DE027FC888200D97DD6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EC4C0DE327FC888200D97DD6 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		EC4C0DE927FC888300D97DD6 /* Dependiject_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Dependiject_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC4C0DED27FC888300D97DD6 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
-		ECCC43312804727E006BED31 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
+		EC4C0DED27FC888300D97DD6 /* PrimaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryViewModelTests.swift; sourceTree = "<group>"; };
+		ECCC43312804727E006BED31 /* PrimaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryViewModel.swift; sourceTree = "<group>"; };
 		ECCC4333280472B4006BED31 /* Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; };
 		ED13DE09199B08AAC34CCC47 /* Pods-Dependiject_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dependiject_Tests.release.xcconfig"; path = "Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -130,10 +140,14 @@
 			children = (
 				EC4C0DDC27FC888100D97DD6 /* Dependiject_ExampleApp.swift */,
 				EC4C0DDE27FC888100D97DD6 /* ContentView.swift */,
-				ECCC43312804727E006BED31 /* ContentViewModel.swift */,
+				ECCC43312804727E006BED31 /* PrimaryViewModel.swift */,
 				ECCC4333280472B4006BED31 /* Services.swift */,
 				EC4C0DE027FC888200D97DD6 /* Assets.xcassets */,
 				EC4C0DE227FC888200D97DD6 /* Preview Content */,
+				634A103A282974E100526130 /* PrimaryView.swift */,
+				634A103C2829765F00526130 /* SecondaryView.swift */,
+				634A103E282977EF00526130 /* SecondaryViewModel.swift */,
+				634A104228298E2B00526130 /* Models.swift */,
 			);
 			path = Dependiject_Example;
 			sourceTree = "<group>";
@@ -149,7 +163,8 @@
 		EC4C0DEC27FC888300D97DD6 /* Dependiject_ExampleTests */ = {
 			isa = PBXGroup;
 			children = (
-				EC4C0DED27FC888300D97DD6 /* Tests.swift */,
+				EC4C0DED27FC888300D97DD6 /* PrimaryViewModelTests.swift */,
+				634A104028298D9A00526130 /* SecondaryViewModelTests.swift */,
 			);
 			path = Dependiject_ExampleTests;
 			sourceTree = "<group>";
@@ -357,9 +372,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC4C0DDF27FC888100D97DD6 /* ContentView.swift in Sources */,
+				634A103D2829765F00526130 /* SecondaryView.swift in Sources */,
 				ECCC4334280472B4006BED31 /* Services.swift in Sources */,
+				634A104328298E2B00526130 /* Models.swift in Sources */,
 				EC4C0DDD27FC888100D97DD6 /* Dependiject_ExampleApp.swift in Sources */,
-				ECCC43322804727E006BED31 /* ContentViewModel.swift in Sources */,
+				ECCC43322804727E006BED31 /* PrimaryViewModel.swift in Sources */,
+				634A103B282974E100526130 /* PrimaryView.swift in Sources */,
+				634A103F282977EF00526130 /* SecondaryViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -368,7 +387,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC43EDA02805F1C60063E5B0 /* Dependiject_Tests-Dependiject_ExampleMocks.generated.swift in Sources */,
-				EC4C0DEE27FC888300D97DD6 /* Tests.swift in Sources */,
+				634A104128298D9A00526130 /* SecondaryViewModelTests.swift in Sources */,
+				EC4C0DEE27FC888300D97DD6 /* PrimaryViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS 14 Example/Dependiject_Example/ContentView.swift
+++ b/iOS 14 Example/Dependiject_Example/ContentView.swift
@@ -11,31 +11,14 @@ import Dependiject
 import Combine
 
 struct ContentView: View {
-    @Store var viewModel = Factory.shared.resolve(ContentViewModel.self)
+    @Store var dataStateAccessor = Factory.shared.resolve(DataStateAccessor.self)
     
     var body: some View {
-        VStack(spacing: 0) {
-            Button("Fetch new data") {
-                Task {
-                    await viewModel.refreshData()
-                }
-            }
-            .padding()
-            
-            Divider()
-            
-            List(viewModel.array, id: \.self) {
-                Text("\($0)")
-            }
-            .listStyle(.grouped)
+        switch dataStateAccessor.dataState {
+        case .unconfirmed:
+            PrimaryView()
+        case .confirmed:
+            SecondaryView()
         }
-    }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView(
-            viewModel: ContentViewModelMock()
-        )
     }
 }

--- a/iOS 14 Example/Dependiject_Example/Dependiject_ExampleApp.swift
+++ b/iOS 14 Example/Dependiject_Example/Dependiject_ExampleApp.swift
@@ -27,10 +27,21 @@ struct Dependiject_ExampleApp: App {
                 DataValidatorImplementation()
             }
             
-            Service(.weak, ContentViewModel.self) { r in
-                ContentViewModelImplementation(
+            MultitypeService(exposedAs: [DataStateUpdater.self, DataStateAccessor.self]) { r in
+                DataStateManagerImplementation()
+            }
+            
+            Service(.weak, PrimaryViewModel.self) { r in
+                PrimaryViewModelImplementation(
                     fetcher: r.resolve(),
-                    validator: r.resolve()
+                    validator: r.resolve(),
+                    updater: r.resolve()
+                )
+            }
+            
+            Service(.weak, SecondaryViewModel.self) { r in
+                SecondaryViewModelImplementation(
+                    updater: r.resolve()
                 )
             }
         }

--- a/iOS 14 Example/Dependiject_Example/Models.swift
+++ b/iOS 14 Example/Dependiject_Example/Models.swift
@@ -1,0 +1,14 @@
+//
+//  Models.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import Foundation
+
+enum DataState {
+    case unconfirmed
+    case confirmed
+}

--- a/iOS 14 Example/Dependiject_Example/PrimaryView.swift
+++ b/iOS 14 Example/Dependiject_Example/PrimaryView.swift
@@ -1,0 +1,42 @@
+//
+//  PrimaryView.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 05/09/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import SwiftUI
+import Dependiject
+
+struct PrimaryView: View {
+    @Store var viewModel = Factory.shared.resolve(PrimaryViewModel.self)
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Button("Fetch new data") {
+                Task {
+                    await viewModel.refreshData()
+                }
+            }
+            .padding()
+            
+            Divider()
+            
+            List(viewModel.array, id: \.self) {
+                Text("\($0)")
+            }
+            .listStyle(.grouped)
+            
+            Button("Confirm Data") {
+                viewModel.confirmData()
+            }
+        }
+    }
+}
+
+struct PrimaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        PrimaryView()
+    }
+}

--- a/iOS 14 Example/Dependiject_Example/PrimaryViewModel.swift
+++ b/iOS 14 Example/Dependiject_Example/PrimaryViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ContentViewModel.swift
+//  PrimaryViewModel.swift
 //  Dependiject_Example
 //
 //  Created by William Baker on 04/11/22.
@@ -8,22 +8,30 @@
 
 import Dependiject
 
-protocol ContentViewModel: AnyObservableObject {
+protocol PrimaryViewModel: AnyObservableObject {
     /// A list of things to display.
     var array: [Int] { get }
     /// Update the array.
     func refreshData() async
+    /// Confirms data, updates global state
+    func confirmData()
 }
 
-final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
+final class PrimaryViewModelImplementation: PrimaryViewModel, ObservableObject {
     @Published var array: [Int] = []
     
     private let fetcher: DataFetcher
     private let validator: DataValidator
+    private let dataStateUpdater: DataStateUpdater
     
-    init(fetcher: DataFetcher, validator: DataValidator) {
+    init(
+        fetcher: DataFetcher,
+        validator: DataValidator,
+        updater: DataStateUpdater
+    ) {
         self.fetcher = fetcher
         self.validator = validator
+        self.dataStateUpdater = updater
     }
     
     func refreshData() async {
@@ -31,12 +39,8 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
         let filteredData = validator.pickValidItems(from: rawData)
         self.array = filteredData
     }
-}
-
-final class ContentViewModelMock: ContentViewModel, ObservableObject {
-    @Published var array: [Int] = [2, 4, 6, 8]
     
-    func refreshData() async {
-        // no-op
+    func confirmData() {
+        dataStateUpdater.setDataState(confirmed: true)
     }
 }

--- a/iOS 14 Example/Dependiject_Example/SecondaryView.swift
+++ b/iOS 14 Example/Dependiject_Example/SecondaryView.swift
@@ -1,0 +1,28 @@
+//
+//  SecondaryView.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import SwiftUI
+import Dependiject
+
+struct SecondaryView: View {
+    var viewModel = Factory.shared.resolve(SecondaryViewModel.self)
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Button("Reset Data") {
+                viewModel.resetData()
+            }
+        }
+    }
+}
+
+struct SecondaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        SecondaryView()
+    }
+}

--- a/iOS 14 Example/Dependiject_Example/SecondaryViewModel.swift
+++ b/iOS 14 Example/Dependiject_Example/SecondaryViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  SecondaryViewModel.swift
+//  Dependiject_Example
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import Dependiject
+
+protocol SecondaryViewModel {
+    /// Go back to Primary view to edit data
+    func resetData()
+}
+
+final class SecondaryViewModelImplementation: SecondaryViewModel {
+    private let dataStateUpdater: DataStateUpdater
+    
+    init(updater: DataStateUpdater) {
+        self.dataStateUpdater = updater
+    }
+    
+    func resetData() {
+        dataStateUpdater.setDataState(confirmed: false)
+    }
+}

--- a/iOS 14 Example/Dependiject_Example/Services.swift
+++ b/iOS 14 Example/Dependiject_Example/Services.swift
@@ -6,6 +6,9 @@
 //  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
 //
 
+import Dependiject
+import Combine
+
 protocol DataFetcher {
     func getData() async -> [Int]
 }
@@ -31,3 +34,28 @@ struct DataValidatorImplementation: DataValidator {
     }
 }
 
+protocol DataStateUpdater {
+    func setDataState(confirmed: Bool)
+}
+
+protocol DataStateAccessor: AnyObservableObject {
+    var dataState: DataState { get }
+}
+
+protocol DataStateManager: DataStateUpdater, DataStateAccessor {}
+
+final class DataStateManagerImplementation: DataStateManager & ObservableObject {
+    @Published var dataState: DataState
+    
+    init() {
+        self.dataState = .unconfirmed
+    }
+    
+    func setDataState(confirmed: Bool) {
+        if confirmed {
+            self.dataState = .confirmed
+        } else {
+            self.dataState = .unconfirmed
+        }
+    }
+}

--- a/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
@@ -60,7 +60,7 @@ class PrimaryViewModelTests: XCTestCase {
         await sut.refreshData()
         
         verify(await mockFetcher.getData()).wasCalled(1)
-        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
+        verify(mockValidator.pickValidItems(from: any())).wasCalled(once)
         
         XCTAssertEqual(sut.array, [1, 2, 3, 4, 5, 6])
     }
@@ -70,6 +70,6 @@ class PrimaryViewModelTests: XCTestCase {
         
         sut.confirmData()
         
-        verify(mockDataStateManager.setDataState(confirmed: true)).wasCalled(1)
+        verify(mockDataStateManager.setDataState(confirmed: true)).wasCalled(once)
     }
 }

--- a/iOS 14 Example/Dependiject_ExampleTests/SecondaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/SecondaryViewModelTests.swift
@@ -23,6 +23,6 @@ class SecondaryViewModelTests: XCTestCase {
     
     func testResetData() {
         sut.resetData()
-        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(1)
+        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(once)
     }
 }

--- a/iOS 14 Example/Dependiject_ExampleTests/SecondaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/SecondaryViewModelTests.swift
@@ -1,0 +1,28 @@
+//
+//  SecondaryViewModelTests.swift
+//  Dependiject_Tests
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import XCTest
+import Dependiject
+import Mockingbird
+@testable import Dependiject_Example
+
+class SecondaryViewModelTests: XCTestCase {
+    var mockDataStateManager: DataStateManagerMock!
+    var sut: SecondaryViewModelImplementation!
+    
+    override func setUp() {
+        super.setUp()
+        mockDataStateManager = mock(DataStateManager.self)
+        sut = SecondaryViewModelImplementation(updater: mockDataStateManager)
+    }
+    
+    func testResetData() {
+        sut.resetData()
+        verify(mockDataStateManager.setDataState(confirmed: false)).wasCalled(1)
+    }
+}

--- a/iOS 14 Example/MockingbirdSupport/Combine/ObservableObjectPublisher.swift
+++ b/iOS 14 Example/MockingbirdSupport/Combine/ObservableObjectPublisher.swift
@@ -1,0 +1,84 @@
+//
+//  ObservableObjectPublisher.swift
+//  Dependiject_Tests
+//
+//  Created by Wesley Boyd on 5/9/22.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import Swift
+
+public enum Subscribers {
+    public struct Demand : Equatable, Comparable, Hashable, Codable, CustomStringConvertible {
+        public static let unlimited: Subscribers.Demand
+        public static let none: Subscribers.Demand
+        public static func max(_ value: Int) -> Subscribers.Demand
+        public var description: String { get }
+        public static func + (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Subscribers.Demand
+        public static func += (lhs: inout Subscribers.Demand, rhs: Subscribers.Demand)
+        public static func + (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func += (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func * (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func *= (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func - (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Subscribers.Demand
+        public static func -= (lhs: inout Subscribers.Demand, rhs: Subscribers.Demand)
+        public static func - (lhs: Subscribers.Demand, rhs: Int) -> Subscribers.Demand
+        public static func -= (lhs: inout Subscribers.Demand, rhs: Int)
+        public static func > (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func >= (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func > (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func >= (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func < (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func < (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func <= (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func <= (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func < (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func <= (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func >= (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func > (lhs: Subscribers.Demand, rhs: Subscribers.Demand) -> Bool
+        public static func == (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func != (lhs: Subscribers.Demand, rhs: Int) -> Bool
+        public static func == (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public static func != (lhs: Int, rhs: Subscribers.Demand) -> Bool
+        public var max: Int? { get }
+        public init(from decoder: Decoder) throws
+        public func encode(to encoder: Encoder) throws
+        public static func == (a: Subscribers.Demand, b: Subscribers.Demand) -> Bool
+        public func hash(into hasher: inout Hasher)
+        public var hashValue: Int { get }
+    }
+    public enum Completion<Failure> where Failure : Error {
+        case finished
+        case failure(Failure)
+    }
+}
+
+public protocol Subscription : Cancellable, CustomCombineIdentifierConvertible {
+    func request(_ demand: Subscribers.Demand)
+}
+
+public protocol Subscriber : CustomCombineIdentifierConvertible {
+    associatedtype Input
+    associatedtype Failure : Error
+    func receive(subscription: Subscription)
+    func receive(_ input: Self.Input) -> Subscribers.Demand
+    func receive(completion: Subscribers.Completion<Self.Failure>)
+}
+
+public protocol Publisher {
+    associatedtype Output
+    associatedtype Failure : Error
+    func receive<S>(subscriber: S)
+    where S : Subscriber, Self.Failure == S.Failure, Self.Output == S.Input
+}
+
+extension Never: Error {}
+
+final public class ObservableObjectPublisher : Publisher {
+    public typealias Output = Void
+    public typealias Failure = Never
+    public init()
+    final public func receive<S>(subscriber: S)
+    where S : Subscriber, S.Failure == Never, S.Input == Void
+    final public func send()
+}

--- a/iOS 14 Example/MockingbirdSupport/Dependiject/AnyObservableObject.swift
+++ b/iOS 14 Example/MockingbirdSupport/Dependiject/AnyObservableObject.swift
@@ -1,0 +1,14 @@
+//
+//  AnyObservableObject.swift
+//  XUI
+//
+//  Created by Paul Kraft on 01.03.21.
+//  Copyright © 2021 QuickBird Studios. All rights reserved.
+//  MIT License
+
+import Swift
+import Combine
+
+public protocol AnyObservableObject: AnyObject {
+    var objectWillChange: ObservableObjectPublisher { get }
+}


### PR DESCRIPTION
## Issue Link

Fixes #7 

## Overview of Changes

This PR adds an example for Mocking a protocol that extends `AnyObservableObject`, and refactors view / viewModel code to make the example tests meaningful.

