### PR TITLE
Make @Store default to RunLoop.main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ formatting guidelines.
 
 ## Unreleased
 
+### Changed
+
+- `@Store` now publishes changes on `RunLoop.main` by default, rather than immediately.
+
 ### Added
 
 - Created a changelog, contributing guidelines, and issue templates.

--- a/iOS 13 Example/Dependiject/ContentView.swift
+++ b/iOS 13 Example/Dependiject/ContentView.swift
@@ -15,7 +15,9 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             Button("Fetch new data") {
-                viewModel.refreshData()
+                Task {
+                    await viewModel.refreshData()
+                }
             }
             .padding()
             

--- a/iOS 13 Example/Dependiject/ContentViewModel.swift
+++ b/iOS 13 Example/Dependiject/ContentViewModel.swift
@@ -12,7 +12,7 @@ protocol ContentViewModel: AnyObservableObject {
     /// A list of things to display.
     var array: [Int] { get }
     /// Update the array.
-    func refreshData()
+    func refreshData() async
 }
 
 final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
@@ -26,8 +26,8 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
         self.validator = validator
     }
     
-    func refreshData() {
-        let rawData = fetcher.getData()
+    func refreshData() async {
+        let rawData = await fetcher.getData()
         let filteredData = validator.pickValidItems(from: rawData)
         self.array = filteredData
     }
@@ -36,7 +36,7 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
 final class ContentViewModelMock: ContentViewModel, ObservableObject {
     @Published var array: [Int] = [2, 4, 6, 8]
     
-    func refreshData() {
+    func refreshData() async {
         // no-op
     }
 }

--- a/iOS 13 Example/Dependiject/Services.swift
+++ b/iOS 13 Example/Dependiject/Services.swift
@@ -7,12 +7,14 @@
 //
 
 protocol DataFetcher {
-    func getData() -> [Int]
+    func getData() async -> [Int]
 }
 
 struct DataFetcherImplementation: DataFetcher {
-    func getData() -> [Int] {
+    func getData() async -> [Int] {
         let upperLimit = Int.random(in: 4...20)
+        // Not noticeably long, but enough to potentially change threads
+        try? await Task.sleep(nanoseconds: 1000)
         return Array(1...upperLimit)
     }
 }

--- a/iOS 13 Example/Tests/Tests.swift
+++ b/iOS 13 Example/Tests/Tests.swift
@@ -16,11 +16,11 @@ class Tests: XCTestCase {
     var mockValidator: DataValidatorMock!
     var sut: ContentViewModel!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         
         mockFetcher = mock(DataFetcher.self)
-        given(mockFetcher.getData()).willReturn([1, 2, 3, 4, 5, 6])
+        given(await mockFetcher.getData()).willReturn([1, 2, 3, 4, 5, 6])
         
         mockValidator = mock(DataValidator.self)
         given(mockValidator.pickValidItems(from: any())).will { $0 }
@@ -48,12 +48,12 @@ class Tests: XCTestCase {
         )
     }
     
-    func testExample() {
-        sut.refreshData()
+    func testExample() async {
+        await sut.refreshData()
+        
+        verify(await mockFetcher.getData()).wasCalled(1)
+        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
         
         XCTAssertEqual(sut.array, [1, 2, 3, 4, 5, 6])
-        
-        verify(mockFetcher.getData()).wasCalled(1)
-        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
     }
 }

--- a/iOS 14 Example/Dependiject_Example/ContentView.swift
+++ b/iOS 14 Example/Dependiject_Example/ContentView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import Dependiject
+import Combine
 
 struct ContentView: View {
     @Store var viewModel = Factory.shared.resolve(ContentViewModel.self)
@@ -15,7 +16,9 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             Button("Fetch new data") {
-                viewModel.refreshData()
+                Task {
+                    await viewModel.refreshData()
+                }
             }
             .padding()
             

--- a/iOS 14 Example/Dependiject_Example/ContentViewModel.swift
+++ b/iOS 14 Example/Dependiject_Example/ContentViewModel.swift
@@ -12,7 +12,7 @@ protocol ContentViewModel: AnyObservableObject {
     /// A list of things to display.
     var array: [Int] { get }
     /// Update the array.
-    func refreshData()
+    func refreshData() async
 }
 
 final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
@@ -26,8 +26,8 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
         self.validator = validator
     }
     
-    func refreshData() {
-        let rawData = fetcher.getData()
+    func refreshData() async {
+        let rawData = await fetcher.getData()
         let filteredData = validator.pickValidItems(from: rawData)
         self.array = filteredData
     }
@@ -36,7 +36,7 @@ final class ContentViewModelImplementation: ContentViewModel, ObservableObject {
 final class ContentViewModelMock: ContentViewModel, ObservableObject {
     @Published var array: [Int] = [2, 4, 6, 8]
     
-    func refreshData() {
+    func refreshData() async {
         // no-op
     }
 }

--- a/iOS 14 Example/Dependiject_Example/Services.swift
+++ b/iOS 14 Example/Dependiject_Example/Services.swift
@@ -7,12 +7,14 @@
 //
 
 protocol DataFetcher {
-    func getData() -> [Int]
+    func getData() async -> [Int]
 }
 
 struct DataFetcherImplementation: DataFetcher {
-    func getData() -> [Int] {
+    func getData() async -> [Int] {
         let upperLimit = Int.random(in: 4...20)
+        // Not noticeably long, but enough to potentially change threads
+        try? await Task.sleep(nanoseconds: 1000)
         return Array(1...upperLimit)
     }
 }

--- a/iOS 14 Example/Dependiject_ExampleTests/Tests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/Tests.swift
@@ -16,11 +16,11 @@ class Tests: XCTestCase {
     var mockValidator: DataValidatorMock!
     var sut: ContentViewModel!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         
         mockFetcher = mock(DataFetcher.self)
-        given(mockFetcher.getData()).willReturn([1, 2, 3, 4, 5, 6])
+        given(await mockFetcher.getData()).willReturn([1, 2, 3, 4, 5, 6])
         
         mockValidator = mock(DataValidator.self)
         given(mockValidator.pickValidItems(from: any())).will { $0 }
@@ -48,12 +48,12 @@ class Tests: XCTestCase {
         )
     }
     
-    func testExample() {
-        sut.refreshData()
+    func testExample() async {
+        await sut.refreshData()
+        
+        verify(await mockFetcher.getData()).wasCalled(1)
+        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
         
         XCTAssertEqual(sut.array, [1, 2, 3, 4, 5, 6])
-        
-        verify(mockFetcher.getData()).wasCalled(1)
-        verify(mockValidator.pickValidItems(from: any())).wasCalled(1)
     }
 }


### PR DESCRIPTION
## Issue Link

Fixes #11

## Overview of Changes

This PR adds an optional Scheduler argument to `@Store` which defaults to `RunLoop.main`, so the user can specify where to receive updates.

### Anything you want to highlight?

I'm not 100% sure on the licensing implications, see the issue for details.

## Test Plan

The example apps have been changed so this is now necessary. If you change the code so that the view does not receive updates on the main thread, either by reverting the changes to `@Store` or by modifying the view as follows:

```diff
 import SwiftUI
 import Dependiject
+import Combine
 
 struct ContentView: View {
-    @Store var viewModel = Factory.shared.resolve(ContentViewModel.self)
+    @Store(on: ImmediateScheduler.shared) var viewModel = Factory.shared.resolve(ContentViewModel.self)
```

then clicking the "fetch new data" button will cause a runtime warning not to publish UI updates from a background thread.