### PR TITLE
Allow documentation to run on any port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ formatting guidelines.
 
 ### Changed
 
+- The documentation can be run on any port when hosted locally, rather than always using port 3000.
 - `MultitypeService` no longer exposes the implementation type by default. It may still be exposed
   explicitly.
 - `@Store` now publishes changes on `RunLoop.main` by default, rather than immediately.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ There are two examples provided:
 
 All documentation is provided via inline doc comments that can be parsed by Xcode.
 
-To view the documentation in a browser, run `./dochost.sh`.
+To view the documentation in a browser, run `./dochost.sh`. By default, it will search for an
+available port to open on, but the port can be set by the environment variable `DOC_PORT`. For
+example, to run it on port 3000, type:  
+`DOC_PORT=3000 ./dochost.sh`  
+Attempting to run on port 0 will result in the default behavior.
 
 ## Automated Tests
 

--- a/docserver/index.js
+++ b/docserver/index.js
@@ -23,7 +23,7 @@ const basePath = path.join(
             }
         },
         host: 'localhost',
-        port: 3000
+        port: process.env.DOC_PORT || 0
     });
 
     await server.register(inert);


### PR DESCRIPTION
## Issue Link

Fixes #15

## Overview of Changes

Rather than always running on port 3000, the documentation server now runs on the port specified by the `DOC_PORT` environment variable. See the README for an example.

If the port is specified as 0, or not specified at all, hapi will search for an available port.

### Anything you want to highlight?

The `??` operator in JavaScript was introduced in node 14, and the documentation server is compatible with node 12. To avoid breaking node 12 compatibility, I have used `||` instead.

It appears that hapi 21 will require node 14 anyways, so if and when we upgrade from hapi 20 to hapi 21, this `||` can be changed to `??`. 

## Test Plan

Run the dochost script in the terminal with various values for `DOC_PORT`.