### PR TITLE
Reference online documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ formatting guidelines.
 
 ### Added
 
+- The podspec now includes a documentation URL.
 - Added documentation for `@Store`.
 - Examples for testing `AnyObservableObject` in both example projects.
 - Added automated tests.

--- a/Dependiject.podspec
+++ b/Dependiject.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
                          'Wesley Boyd' => 'u4qr@protonmail.com' }
   s.source           = { :git => 'https://github.com/Tiny-Home-Consulting/Dependiject.git', :tag => s.version }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+  s.documentation_url = 'https://dependiject.tinyhomeconsultingllc.com/documentation/'
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ platforms that support SwiftUI.
 To install the library with CocoaPods requires version 1.10.0 or later, but we recommend using
 version 1.11.0 or later.
 
-To view the documentation in-browser (see [Documentation][4] below) requires CocoaPods 1.11.3 and
+To host the documentation locally (see [Documentation][4] below) requires CocoaPods 1.11.3 and
 NodeJS 12.0.0 or later, and expects yarn to be installed globally.
 
 ## Installation
@@ -119,9 +119,10 @@ There are two examples provided:
 
 All documentation is provided via inline doc comments that can be parsed by Xcode.
 
-To view the documentation in a browser, run `./dochost.sh`. By default, it will search for an
-available port to open on, but the port can be set by the environment variable `DOC_PORT`. For
-example, to run it on port 3000, type:  
+The documentation is hosted at <https://dependiject.tinyhomeconsultingllc.com/documentation/>. To
+host it locally, run `./dochost.sh`. By default, it will search for an available port to open on,
+but the port can be set by the environment variable `DOC_PORT`. For example, to run it on port 3000,
+type:  
 `DOC_PORT=3000 ./dochost.sh`  
 Attempting to run on port 0 will result in the default behavior.
 


### PR DESCRIPTION
## Issue Link

Fixes #19

## Overview of Changes

This PR updates the README to mention that the documentation is hosted online, and adds a `documentation_url` to the podspec.

### Anything you want to highlight?

N/A

## Test Plan

N/A
