### PR TITLE
Change version numbers in the bug report template to x.y.z

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -40,21 +40,21 @@ labels:
     Replace the entries in the table below with the actual versions you're using.
 -->
 
-| Software    |  Version   |
-|:------------|:-----------|
-| macOS       | `v12.3.1`  |
-| Xcode       | `v13.3.1`  |
-| Dependiject | `v0.1.0`   |
+| Software    | Version |
+|:------------|:--------|
+| macOS       | `x.y.z` |
+| Xcode       | `x.y.z` |
+| Dependiject | `x.y.z` |
 
 <!--
     If you're using CocoaPods, add the following line to the table:
-        | CocoaPods   | `v1.11.3`  |
+        | CocoaPods   | `x.y.z` |
 -->
 
 <!--
     If the problem pertains to the documentation server, add the following lines to the table:
-        | NodeJS      | `v16.15.0` |
-        | yarn        | `v1.22.18` |
+        | NodeJS      | `x.y.z` |
+        | yarn        | `x.y.z` |
 -->
 
 [1]: https://github.com/Tiny-Home-Consulting/Dependiject/issues?q=is%3Aissue


### PR DESCRIPTION
## Issue Link

Fixes #22

## Overview of Changes

This PR changes the version numbers in the bug report template from actual version numbers (like `1.11.3`) to `x.y.z`, so that it doesn't have to be continually updated as new versions of other software are released.

### Anything you want to highlight?

N/A

## Test Plan

N/A