### PR TITLE
Add check for circular dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ formatting guidelines.
 
 ### Added
 
+- The factory can now check for circular dependencies. This is enabled by default in debug builds.
 - The podspec now includes a documentation URL.
 - Added documentation for `@Store`.
 - Examples for testing `AnyObservableObject` in both example projects.

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -8,8 +8,8 @@
 
 /// When to check for errors.
 ///
-/// This is used by the ``Factory`` to determine whether to error if the calls to ``Resolver/resolve(_:name:)`` exceed a
-/// certain depth.
+/// This is used by the ``Factory`` to determine whether to error if the calls to
+/// ``Resolver/resolve(_:name:)`` exceed a certain depth.
 public enum ErrorCheckMode {
     /// Never perform any error checking.
     case never

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -24,7 +24,7 @@ public enum ErrorCheckMode {
     case always
 }
 
-/// The options struct used by the ``Factory`` for sanity checks.
+/// The options struct used by the ``Factory`` to configure error checks.
 public struct ResolutionOptions {
     /// The mode used to check for errors.
     public var mode: ErrorCheckMode

--- a/iOS 13 Example/Podfile.lock
+++ b/iOS 13 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: ecbefd07b5c4fabb5e06e8b685572c8fd2f6fd6f
+  Dependiject: edf4ad7005a5027b7084fc0d2f1199599e077231
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 69b53b587fc6c75eef571f57668f2e8e0e0ecf77

--- a/iOS 14 Example/Podfile.lock
+++ b/iOS 14 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: ecbefd07b5c4fabb5e06e8b685572c8fd2f6fd6f
+  Dependiject: edf4ad7005a5027b7084fc0d2f1199599e077231
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 36b8602ef54137bf035edec6b6d987f87e3dfa23


### PR DESCRIPTION
## Issue Link

Fixes #25

## Overview of Changes

This PR adds the ability to track dependency resolution depth. If the depth exceeds a certain amount (100 by default), the program may terminate, depending on the error-checking mode (by default, this is only for debug builds and not release builds).

### Anything you want to highlight?

N/A

## Test Plan

This can't be tested automatically, since it would crash the test runner. However, examples of what should trigger this check are present in the documentation and in the linked issue.