### PR TITLE
Fix example projects for iOS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ formatting guidelines.
 
 ## Unreleased
 
+### Fixed
+
+- The example projects now look the same when run on iOS 16 as on earlier versions.
+
 ### Added
 
 - Added automated tests for `@Store`.

--- a/iOS 13 Example/Dependiject/PrimaryView.swift
+++ b/iOS 13 Example/Dependiject/PrimaryView.swift
@@ -23,14 +23,23 @@ struct PrimaryView: View {
             
             Divider()
             
-            List(viewModel.array, id: \.self) {
-                Text("\($0)")
+            // If there's not enough items to fill the whole area, the background will be colored
+            // UIColor.systemGroupedBackground. Starting in iOS 16, however, this does not happen
+            // for a list that is completely empty.
+            if #available(iOS 16, *),
+               viewModel.array.isEmpty {
+                Color(UIColor.systemGroupedBackground)
+            } else {
+                List(viewModel.array, id: \.self) {
+                    Text("\($0)")
+                }
+                .listStyle(.grouped)
             }
-            .listStyle(.grouped)
             
             Button("Confirm Data") {
                 viewModel.confirmData()
             }
+            .padding()
         }
     }
 }

--- a/iOS 14 Example/Dependiject_Example/PrimaryView.swift
+++ b/iOS 14 Example/Dependiject_Example/PrimaryView.swift
@@ -23,14 +23,23 @@ struct PrimaryView: View {
             
             Divider()
             
-            List(viewModel.array, id: \.self) {
-                Text("\($0)")
+            // If there's not enough items to fill the whole area, the background will be colored
+            // UIColor.systemGroupedBackground. Starting in iOS 16, however, this does not happen
+            // for a list that is completely empty.
+            if #available(iOS 16, *),
+               viewModel.array.isEmpty {
+                Color(UIColor.systemGroupedBackground)
+            } else {
+                List(viewModel.array, id: \.self) {
+                    Text("\($0)")
+                }
+                .listStyle(.grouped)
             }
-            .listStyle(.grouped)
             
             Button("Confirm Data") {
                 viewModel.confirmData()
             }
+            .padding()
         }
     }
 }


### PR DESCRIPTION
## Issue Link

Fixes #27

## Overview of Changes

This PR changes what is displayed when the list is empty on iOS 16. It also adds padding to the "Confirm Data" button, as it was very close to the bottom safe area.

### Anything you want to highlight?

N/A

## Test Plan

This should be tested both in Xcode 14 and in some earlier version of Xcode, to ensure that the project compiles even as it references an iOS version Xcode may not know about.

I have tested it locally on the iOS 16 simulator, and it appears to work as intended:
<img width="433" alt="Screen Shot 2022-09-14 at 3 01 43 PM" src="https://user-images.githubusercontent.com/25109429/190240375-188bea03-935c-428e-9d32-5ad303b9e251.png">
