### PR TITLE
Add automated tests for @Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ formatting guidelines.
 
 ## Unreleased
 
+### Added
+
+- Added automated tests for `@Store`.
+
 ## [0.2.0] - 2022-09-14
 
 ### Changed

--- a/Dependiject/Store.swift
+++ b/Dependiject/Store.swift
@@ -41,7 +41,7 @@ public struct Store<ObjectType> {
     /// The underlying object being stored.
     public let wrappedValue: ObjectType
     
-    @ObservedObject private var observableObject: ErasedObservableObject
+    @ObservedObject internal var observableObject: ErasedObservableObject
     
     /// A projected value which has the same properties as the wrapped value, but presented as
     /// bindings.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Entwine",
+        "repositoryURL": "https://github.com/tcldr/Entwine.git",
+        "state": {
+          "branch": null,
+          "revision": "cd90cfb2510c35ba082d9c7a8910bdacc6fa840f",
+          "version": "0.9.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,12 @@ let package = Package(
             targets: ["Dependiject"]
         )
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/tcldr/Entwine.git",
+            .upToNextMajor(from: "0.9.1")
+        )
+    ],
     targets: [
         .target(
             name: "Dependiject",
@@ -27,7 +33,8 @@ let package = Package(
         .testTarget(
             name: "DependijectTests",
             dependencies: [
-                .target(name: "Dependiject")
+                .target(name: "Dependiject"),
+                .product(name: "EntwineTest", package: "Entwine")
             ],
             path: "Tests"
         )

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -1,0 +1,84 @@
+//
+//  StoreTests.swift
+//  
+//
+//  Created by William Baker on 09/15/2022.
+//
+
+import XCTest
+import EntwineTest
+import Combine
+@testable import Dependiject
+
+fileprivate class TestObservable: ObservableObject, AnyObservableObject {
+    var setterCalled = false
+    
+    private var _setterTracked = 0
+    var setterTracked: Int {
+        get {
+            return _setterTracked
+        }
+        set {
+            setterCalled = true
+            _setterTracked = newValue
+        }
+    }
+    
+    @Published var published = 0
+    var notPublished = 0
+}
+
+class StoreTests: XCTestCase {
+    func test_projectedValue_bindsWrappedValue() {
+        // This test does not subscribe to the publisher, so the scheduler used doesn't matter.
+        @Store var observable = TestObservable()
+        
+        $observable.setterTracked.wrappedValue = 1
+        
+        XCTAssertTrue(
+            observable.setterCalled,
+            "Updating property of projectedValue should call wrappedValue property setter"
+        )
+        XCTAssertEqual(
+            observable.setterTracked,
+            $observable.setterTracked.wrappedValue,
+            "wrappedValue property should match projectedValue property"
+        )
+    }
+    
+    func test_settingPublishedValue_causesUpdate() {
+        var updated = false
+        let scheduler = TestScheduler()
+        @Store(on: scheduler) var observable = TestObservable()
+        
+        // This must be stored somewhere. If we discard it it will automatically unsubscribe from
+        // the observable.
+        let cancellable = _observable.observableObject.objectWillChange.sink { _ in
+            updated = true
+        }
+        
+        observable.published = 1
+        XCTAssertFalse(updated, "Update should publish only when the given scheduler allows it")
+        scheduler.resume()
+        XCTAssertTrue(updated, "Update should be published when @Published property is changed")
+        
+        // This silences a warning that this variable is never used. As mentioned above, it must
+        // exist.
+        _ = cancellable
+    }
+    
+    func test_settingNonPublishedValue_doesNotCauseUpdate() {
+        var updated = false
+        // For this test, if any results are published, they should be published immediately.
+        @Store(on: ImmediateScheduler.shared) var observable = TestObservable()
+        
+        let cancellable = _observable.observableObject.objectWillChange.sink { _ in
+            updated = true
+        }
+        
+        observable.notPublished = 1
+        XCTAssertFalse(updated, "Update should not be sent when non-@Published property is changed")
+        
+        _ = cancellable
+    }
+}

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -29,6 +29,12 @@ fileprivate class TestObservable: ObservableObject, AnyObservableObject {
 }
 
 class StoreTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        self.continueAfterFailure = false
+    }
+    
     func test_projectedValue_bindsWrappedValue() {
         // This test does not subscribe to the publisher, so the scheduler used doesn't matter.
         @Store var observable = TestObservable()


### PR DESCRIPTION
## Issue Link

Fixes #29

## Overview of Changes

This PR adds automated tests for `@Store`, as outlined in the issue. One of its properties was changed from `private` to `internal` so it could be accessed in the tests.

### Anything you want to highlight?

This does add an external dependency, on [Entwine][1]. Some alternatives considered:
- [combine-schedulers][2], which is more active, but also requires Swift 5.5. Using this would delay this PR from version 0.2.1 to 1.0.0.
- [SchedulerKit][3], which hasn't been updated in over a year and isn't as well-documented as the other two.

The `Package.resolved` file is the lockfile, akin to `Podfile.lock` or `yarn.lock`.

## Test Plan

Run the tests in Xcode or with `swift test`.

[1]: https://github.com/tcldr/Entwine
[2]: https://github.com/pointfreeco/combine-schedulers
[3]: https://github.com/scheduler-kit/SchedulerKit