### PR TITLE
Run all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ formatting guidelines.
 
 ### Added
 
+- Added a script to run all tests, including for the example projects.
 - Added automated tests for `@Store`.
 
 ## [0.2.0] - 2022-09-14

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ platforms that support SwiftUI.
 To install the library with CocoaPods requires version 1.10.0 or later, but we recommend using
 version 1.11.0 or later.
 
+To run the tests from the command line (see [Automated Tests][9] below) requires CocoaPods 1.11.3
+and NodeJS 6 or later.
+
 To host the documentation locally (see [Documentation][4] below) requires CocoaPods 1.11.3 and
-NodeJS 12.0.0 or later, and expects yarn to be installed globally.
+NodeJS 12 or later, and expects yarn to be installed globally.
 
 ## Installation
 
@@ -143,3 +146,4 @@ Dependiject is released under the MPL-2.0 license. See [LICENSE][7] for details.
 [6]: ./iOS%2014%20Example/
 [7]: ./LICENSE
 [8]: https://img.shields.io/cocoapods/v/Dependiject
+[9]: #automated-tests

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Attempting to run on port 0 will result in the default behavior.
 
 ## Automated Tests
 
-To run the automated tests, simply run the command `swift test` in the terminal. The tests can also
-be run in Xcode.
+To run the automated tests, simply run the command `./runtests.sh` in the terminal. The tests can
+also be run in Xcode.
 
 ## License
 

--- a/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
+++ b/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
-				"$(SRCROOT)/MockingbirdMocks/swiftdi_Tests-swiftdi_ExampleMocks.generated.swift",
+				"$(SRCROOT)/MockingbirdMocks/Dependiject_Tests-Dependiject_ExampleMocks.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/iOS 14 Example/Dependiject_Example.xcodeproj/project.pbxproj
+++ b/iOS 14 Example/Dependiject_Example.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
-				"$(SRCROOT)/MockingbirdMocks/swiftdi_Tests-swiftdi_ExampleMocks.generated.swift",
+				"$(SRCROOT)/MockingbirdMocks/Dependiject_Tests-Dependiject_ExampleMocks.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+
+#  dochost.sh
+#  Dependiject
+#
+#  Created by William Baker on 09/20/22.
+#  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+#
+
+# Get the simulator list and pick a device.
+# The xcrun command gives a formatted list of simulators, with different OS's separated by headings
+# that start with '--'. The grep command removes these headings.
+# Since simulators are listed in order from oldest to newest, picking the last one (with tail) will
+# ensure that the device is a new enough iOS to run the example projects.
+# Finally, parse out the device's id (a capitalized, hyphenated UUID) using a regex.
+device=$(xcrun simctl list devices iPhone available | grep -v -- -- | tail -n 1)
+deviceId=$(node -p "/[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}/u.exec('$device')[0]")
+
+set -e
+
+swift test
+
+cd "iOS 13 Example"
+pod install
+xcodebuild -workspace Dependiject.xcworkspace -scheme Dependiject_Example -destination \
+    "id=$deviceId" test
+
+cd "../iOS 14 Example"
+pod install
+xcodebuild -workspace Dependiject_Example.xcworkspace -scheme Dependiject_Example -destination \
+    "id=$deviceId" test

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,6 +7,8 @@
 #  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
 #
 
+set -eo pipefail
+
 # Get the simulator list and pick a device.
 # The xcrun command gives a formatted list of simulators, with different OS's separated by headings
 # that start with '--'. The grep command removes these headings.
@@ -15,8 +17,6 @@
 # Finally, parse out the device's id (a capitalized, hyphenated UUID) using a regex.
 device=$(xcrun simctl list devices iPhone available | grep -v -- -- | tail -n 1)
 deviceId=$(node -p "/[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}/u.exec('$device')[0]")
-
-set -e
 
 swift test
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -18,7 +18,11 @@ set -eo pipefail
 device=$(xcrun simctl list devices iPhone available | grep -v -- -- | tail -n 1)
 deviceId=$(node -p "/[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}/u.exec('$device')[0]")
 
-swift test
+swift test || {
+    exitCode=$?
+    printf '\n\e[1;31m** TEST FAILED **\e[m\n\n'
+    return $exitCode
+}
 
 cd "iOS 13 Example"
 pod install


### PR DESCRIPTION
## Issue Link

Fixes #31

## Overview of Changes

This PR adds a script to run all tests, including the example projects' tests, from the command line. It also entails a change to the pbxproj files to allow the test script to generate mocks automatically.

### Anything you want to highlight?

N/A

## Test Plan

Run the test script.
