### PR TITLE
Add registration of external constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ formatting guidelines.
 
 ### Added
 
+- Added a way to register existing instances as dependencies.
 - Added a script to run all tests, including for the example projects.
 - Added automated tests for `@Store`.
 

--- a/Dependiject/RegistrationConvertible.swift
+++ b/Dependiject/RegistrationConvertible.swift
@@ -56,7 +56,7 @@ public enum Scope {
     case transient
     /// Create a lazy-loaded singleton, and re-use the same one for further requests.
     /// - Note: This scope is for singletons that are created by the callback. If the singleton is
-    /// created elsewhere and the callback only accesses it, ``transient`` is more memory-efficient.
+    /// created elsewhere, use ``Service/init(constant:_:_:)`` instead.
     case singleton
     /// Re-use an existing instance if it exists, but do not hold onto an unused instance.
     /// - Important: This scope can only be used with classes and actors. Value types are not
@@ -68,6 +68,7 @@ public enum Scope {
 public struct Service: RegistrationConvertible {
     public let registration: Registration
     
+    /// Create a lazily-loaded service.
     /// - Parameters:
     ///   - scope: How often to call the registration callback.
     ///   - type: The type to register the service as. This may be different from the actual type of
@@ -92,5 +93,17 @@ public struct Service: RegistrationConvertible {
         case .weak:
             self.registration = WeakRegistration(type, name, callback)
         }
+    }
+    
+    /// Create a service wrapping an existing instance.
+    /// - Parameters:
+    ///   - constant: The value to register.
+    ///   - type: The type to register the service as. This may be different from the actual type of
+    ///   the object, for example it may be the superclass, or a protocol that the object conforms
+    ///   to.
+    ///   - name: The name to give the registration object. This can usually be `nil`; it is only
+    ///   necessary when registering two different services of the same type.
+    public init<T>(constant: T, _ type: T.Type, _ name: String? = nil) {
+        self.registration = ConstantRegistration(type, name, constant)
     }
 }

--- a/Tests/DuplicateRegistrationTest.swift
+++ b/Tests/DuplicateRegistrationTest.swift
@@ -20,16 +20,16 @@ class DuplicateRegistrationTest: XCTestCase {
     func test_duplicateRegistration_laterOverridesEarlier() {
         // set up the dependency container more than once
         Factory.register {
-            Service(.transient, String.self) { _ in "earlier" }
+            Service(constant: "earlier", String.self)
         }
         
         Factory.register {
-            Service(.transient, Int.self) { _ in 1 }
-            Service(.transient, Int.self) { _ in 2 }
+            Service(constant: 1, Int.self)
+            Service(constant: 2, Int.self)
         }
         
         Factory.register {
-            Service(.transient, String.self) { _ in "later" }
+            Service(constant: "later", String.self)
         }
         
         // check that only the latter of each type is retrievable

--- a/Tests/RegistrationNameTests.swift
+++ b/Tests/RegistrationNameTests.swift
@@ -20,9 +20,9 @@ class RegistrationNameTests: XCTestCase {
     func test_names_disambiguate() {
         // set up the dependency container
         Factory.register {
-            Service(.transient, String.self, nil) { _ in "unnamed" }
-            Service(.transient, String.self, "1") { _ in "named 1" }
-            Service(.transient, String.self, "2") { _ in "named 2" }
+            Service(constant: "unnamed", String.self, nil)
+            Service(constant: "named 1", String.self, "1")
+            Service(constant: "named 2", String.self, "2")
         }
         
         // ensure the default is unnamed

--- a/Tests/ScopeTests.swift
+++ b/Tests/ScopeTests.swift
@@ -150,4 +150,43 @@ class ScopeTests: XCTestCase {
         // check that it can be retrieved
         _ = Factory.shared.resolve(Int.self)
     }
+    
+    /// Test that `Service(constant:_:_:)` grabs the object eagerly but only once.
+    func test_constant_isEager() {
+        // set up the dependency container
+        Factory.register {
+            Service(constant: ConstructorCounter(), ConstructorCounter.self)
+        }
+        
+        // Syntactically, that looks like it already called the init, but that's not necessarily
+        // given (e.g. `@autoclosure`).
+        XCTAssertEqual(
+            ConstructorCounter.count,
+            1,
+            "Expected 1 constant instance but found \(ConstructorCounter.count)"
+        )
+        
+        // grab the instance more than once
+        _ = Factory.shared.resolve(ConstructorCounter.self)
+        _ = Factory.shared.resolve(ConstructorCounter.self)
+        _ = Factory.shared.resolve(ConstructorCounter.self)
+        
+        // assert that only one was created
+        XCTAssertEqual(
+            ConstructorCounter.count,
+            1,
+            "Expected 1 constant instance but saw \(ConstructorCounter.count)"
+        )
+    }
+    
+    /// Test that `Service(constant:_:_:)` allows value types.
+    func test_constant_allowsStructs() {
+        // set up the dependency container
+        Factory.register {
+            Service(constant: 1, Int.self)
+        }
+        
+        // check that it can be retrieved
+        _ = Factory.shared.resolve(Int.self)
+    }
 }

--- a/iOS 13 Example/Tests/PrimaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/PrimaryViewModelTests.swift
@@ -36,17 +36,14 @@ class PrimaryViewModelTests: XCTestCase {
          */
         
         Factory.register {
-            Service(.transient, DataFetcher.self) { _ in
-                self.mockFetcher
-            }
+            Service(constant: self.mockFetcher, DataFetcher.self)
             
-            Service(.transient, DataValidator.self) { _ in
-                self.mockValidator
-            }
+            Service(constant: self.mockValidator, DataValidator.self)
             
-            MultitypeService(exposedAs: [DataStateAccessor.self, DataStateUpdater.self]) { _ in
+            MultitypeService(
+                exposedAs: [DataStateAccessor.self, DataStateUpdater.self],
                 self.mockDataStateManager
-            }
+            )
         }
         
         sut = PrimaryViewModelImplementation(

--- a/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
@@ -36,17 +36,14 @@ class PrimaryViewModelTests: XCTestCase {
          */
         
         Factory.register {
-            Service(.transient, DataFetcher.self) { _ in
-                self.mockFetcher
-            }
+            Service(constant: self.mockFetcher, DataFetcher.self)
             
-            Service(.transient, DataValidator.self) { _ in
-                self.mockValidator
-            }
+            Service(constant: self.mockValidator, DataValidator.self)
             
-            MultitypeService(exposedAs: [DataStateAccessor.self, DataStateUpdater.self]) { _ in
+            MultitypeService(
+                exposedAs: [DataStateAccessor.self, DataStateUpdater.self],
                 self.mockDataStateManager
-            }
+            )
         }
         
         sut = PrimaryViewModelImplementation(


### PR DESCRIPTION
## Issue Link

Fixes #21 

## Overview of Changes

This PR adds the `ConstantRegistration` type, and new initializers to `Service` and `MultitypeService`, to register existing objects as dependencies.

### Anything you want to highlight?

For better organization, I changed `TransientRegistration` to a struct (as noted in the **`Remark`** above it) and put it next to `ConstantRegistration`. This looks a little weird in the diff.

## Test Plan

I added new tests to check the new initializers, in the same format as the existing tests. Some of the tests for which scope is less important (such as the registration name tests) I also changed to use this.
