### PR TITLE
Add async overload for resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ formatting guidelines.
 
 ### Added
 
+- Added a thread-safe overload for `resolve(_:name:)`, and documented other functions as not
+  thread-safe.
 - Added a script to run all tests, including for the example projects.
 - Added automated tests for `@Store`.
 

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -123,7 +123,7 @@ public class Factory: Resolver {
     /// `[Registration]`, as a top-level expression. For an example of this, see
     /// ``MultitypeService``.
     ///
-    /// - Important: This function is not thread-safe. Ensure you do not call it concurrently from
+    /// - Warning: This function is not thread-safe. Ensure you do not call it concurrently from
     /// multiple threads.
     public static func register(@RegistrationBuilder builder: () -> [Registration]) {
         self.shared.registrations += builder()

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -9,7 +9,7 @@
 /// When to check for errors.
 ///
 /// This is used by the ``Factory`` to determine whether to error if the calls to
-/// ``Resolver/resolve(_:name:)`` exceed a certain depth.
+/// ``Factory/resolve(_:name:)-6pyni`` exceed a certain depth.
 public enum ErrorCheckMode {
     /// Never perform any error checking.
     case never
@@ -122,6 +122,9 @@ public class Factory: Resolver {
     /// It is also possible to use a sequence of registration-convertible objects, such as a
     /// `[Registration]`, as a top-level expression. For an example of this, see
     /// ``MultitypeService``.
+    ///
+    /// - Important: This function is not thread-safe. Ensure you do not call it concurrently from
+    /// multiple threads.
     public static func register(@RegistrationBuilder builder: () -> [Registration]) {
         self.shared.registrations += builder()
     }

--- a/Tests/ConcurrencyTest.swift
+++ b/Tests/ConcurrencyTest.swift
@@ -1,0 +1,40 @@
+//
+//  ConcurrencyTest.swift
+//  
+//
+//  Created by William Baker on 09/23/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import XCTest
+@testable import Dependiject
+
+fileprivate final class C: Sendable {}
+
+class ConcurrencyTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        self.continueAfterFailure = false
+    }
+    
+    func test_concurrentResolutions() async {
+        // set up the DI container
+        Factory.register {
+            Service(.weak, C.self) { _ in C() }
+            Service(.singleton, Int.self) { _ in 1 }
+        }
+        
+        // create a bunch of concurrently-executing tasks that all try to resolve the same thing
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<1000 {
+                group.addTask {
+                    _ = await Factory.shared.resolve(C.self)
+                    _ = await Factory.shared.resolve(Int.self)
+                }
+            }
+            
+            await group.waitForAll()
+        }
+    }
+}

--- a/iOS 13 Example/Tests/PrimaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/PrimaryViewModelTests.swift
@@ -50,9 +50,9 @@ class PrimaryViewModelTests: XCTestCase {
         }
         
         sut = PrimaryViewModelImplementation(
-            fetcher: Factory.shared.resolve(),
-            validator: Factory.shared.resolve(),
-            updater: Factory.shared.resolve()
+            fetcher: await Factory.shared.resolve(),
+            validator: await Factory.shared.resolve(),
+            updater: await Factory.shared.resolve()
         )
     }
     

--- a/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
@@ -50,9 +50,9 @@ class PrimaryViewModelTests: XCTestCase {
         }
         
         sut = PrimaryViewModelImplementation(
-            fetcher: Factory.shared.resolve(),
-            validator: Factory.shared.resolve(),
-            updater: Factory.shared.resolve()
+            fetcher: await Factory.shared.resolve(),
+            validator: await Factory.shared.resolve(),
+            updater: await Factory.shared.resolve()
         )
     }
     


### PR DESCRIPTION
## Issue Link

Relates to, but does not close, #35 

## Overview of Changes

This PR adds a thread-safe, `async` overload of the `resolve(_:name:)` method, so that the caller may opt into thread safety. To avoid breaking Swift 5.4, this declaration is wrapped in a `#if` directive.

### Anything you want to highlight?

This is a temporary fix; a better fix will be in version 1.0. See the linked issue for details.

## Test Plan

In the concurrency test, removing the `await` operator from before the `Factory.shared.resolve` calls should still allow it to compile, but then crash when you run it. Due to the nature of concurrency, it may not crash every time you run it.
