### PR TITLE
Make Factory thread-safe using NSRecursiveLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ formatting guidelines.
 
 ### Fixed
 
+- The factory is now thread-safe: its functions may be simultaneously called on different threads.
 - The example projects now look the same when run on iOS 16 as on earlier versions.
 
 ### Added

--- a/Dependiject.podspec
+++ b/Dependiject.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Dependiject'
   s.version          = '0.2.0'
-  s.summary          = 'Dependiject provides simple and flexible dependency injection for testability and inversion of control in SwiftUI apps.'
+  s.summary          = 'Dependiject provides simple, flexible, and thread-safe dependency injection for testability and inversion of control in SwiftUI apps.'
 
   s.homepage         = 'https://github.com/Tiny-Home-Consulting/Dependiject'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ![Supported Platforms][3]
 ![Version][8]
 
-Dependiject provides simple and flexible dependency injection for testability and inversion of
-control in SwiftUI apps.
+Dependiject provides simple, flexible, and thread-safe dependency injection for testability and
+inversion of control in SwiftUI apps.
 
 ## Overview
 

--- a/Tests/ParallelResolutionTest.swift
+++ b/Tests/ParallelResolutionTest.swift
@@ -1,0 +1,33 @@
+//
+//  ParallelResolutionTest.swift
+//  
+//
+//  Created by William Baker on 09/27/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+import XCTest
+@testable import Dependiject
+
+fileprivate class C {}
+
+class ParallelResolutionTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        self.continueAfterFailure = false
+    }
+    
+    func test_parallelResolutions() {
+        Factory.register {
+            // test both of the stateful registration types
+            Service(.singleton, Int.self) { _ in 1 }
+            Service(.weak, C.self) { _ in C() }
+        }
+        
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            _ = Factory.shared.resolve(C.self)
+            _ = Factory.shared.resolve(Int.self)
+        }
+    }
+}

--- a/iOS 13 Example/Podfile.lock
+++ b/iOS 13 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 7dd63d82fc02e7fe898d36bb09041f226f28dda7
+  Dependiject: 8f500a31af5ad22a2404c899e00e584878600c75
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 69b53b587fc6c75eef571f57668f2e8e0e0ecf77

--- a/iOS 14 Example/Podfile.lock
+++ b/iOS 14 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 7dd63d82fc02e7fe898d36bb09041f226f28dda7
+  Dependiject: 8f500a31af5ad22a2404c899e00e584878600c75
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 36b8602ef54137bf035edec6b6d987f87e3dfa23


### PR DESCRIPTION
## Issue Link

Fixes #35 

## Overview of Changes

This PR protects the methods of `Factory` with an `NSRecursiveLock`. This ensures that it can safely be called from any thread.

### Anything you want to highlight?

This PR is meant as a more user-friendly and both backwards- and forwards-compatible alternative to #36. As it turns out, Swift concurrency is not required to solve the problem.

## Test Plan

Try to call `Factory.register` and `Factory.shared.resolve` in various ways in concurrent contexts. I was unable to get it to break.
