### PR TITLE
Add error for weak service resolved by singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ formatting guidelines.
 
 ## Unreleased
 
+### Added
+
+- Singletons which depend on weak services now trigger an assertion failure by default.
+
 ### Changed
 
+- The default options are now reflected in the initializer for `ResolutionOptions`.
 - The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.
 - The `name` argument to `Service.init` is now a labeled argument, to better match `resolve`.
 

--- a/Tests/ScopeTests.swift
+++ b/Tests/ScopeTests.swift
@@ -17,6 +17,7 @@ fileprivate class ConstructorCounter {
         Self.count += 1
     }
 }
+
 fileprivate class DependsOnClass {
     weak var obj: ConstructorCounter?
     


### PR DESCRIPTION
## Issue Link

Fixes #32

## Overview of Changes

This PR adds a check for resolving a weak service as a dependency for a singleton. Such a resolution promotes the weak service to itself be a singleton, unless the singleton stores it in a weak property.

Since it is possible for this to work as declared, it is possible to opt out of the check.

### Anything you want to highlight?

I'm not completely satisfied with how `WeakRegistration` accesses the options. I'm open to suggestions in this regard.

## Test Plan

Removing the line `Factory.options.singletonAcceptsWeak = true` from the new test should cause it to crash, unless `Factory.options.mode` is set to `.never`.