### PR TITLE
Fix @Store concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ formatting guidelines.
 
 ## Unreleased
 
+### Removed
+
+- Dropped support for Swift &lt; 5.5 (Xcode &lt; 13.2).
+
+### Fixed
+
+- The `@Store` property wrapper now follows Swift's concurrency rules.
+
 ### Added
 
 - Singletons which depend on weak services now trigger an assertion failure by default.

--- a/Dependiject.podspec
+++ b/Dependiject.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = '13.0'
     
     s.cocoapods_version = '~> 1.10'
-    s.swift_versions = '5.4'
+    s.swift_versions = '5.5'
     s.source_files = 'Dependiject/**/*.swift'
     
     s.frameworks = 'SwiftUI', 'Combine'

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// This is used by the ``Factory`` for sanity checks, such as detecting circular dependencies and
 /// validating scopes.
-public enum ErrorCheckMode {
+public enum ErrorCheckMode: Sendable {
     /// Never perform any error checking.
     case never
     /// Error check using
@@ -27,7 +27,7 @@ public enum ErrorCheckMode {
 }
 
 /// The options struct used by the ``Factory`` to configure error checks.
-public struct ResolutionOptions {
+public struct ResolutionOptions: Sendable {
     /// The mode used to check for errors.
     public var mode: ErrorCheckMode
     /// The maximum depth of the dependency tree.
@@ -88,7 +88,7 @@ internal protocol SingletonCheckingResolver: Resolver {
 }
 
 /// The class to which you register dependencies.
-public final class Factory: SingletonCheckingResolver {
+public final class Factory: SingletonCheckingResolver, @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var registrations: [Registration] = []
     private var resolutionDepth: UInt = 0
@@ -196,9 +196,3 @@ public final class Factory: SingletonCheckingResolver {
         }
     }
 }
-
-#if swift(>=5.5)
-extension Factory: @unchecked Sendable {
-}
-#endif
-

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ struct SomeView: View {
 
 ## Requirements
 
-To use this library requires Xcode 12.5 / Swift 5.4 or later. Dependiject is supported for all
+To use this library requires Xcode 13.2 / Swift 5.5 or later. Dependiject is supported for all
 platforms that support SwiftUI.
 
 To install the library with CocoaPods requires version 1.10.0 or later, but we recommend using
@@ -138,7 +138,7 @@ also be run in Xcode.
 
 Dependiject is released under the MPL-2.0 license. See [LICENSE][7] for details.
 
-[1]: https://img.shields.io/badge/swift-~%3E%205.4-orange
+[1]: https://img.shields.io/badge/swift-~%3E%205.5-orange
 [2]: https://img.shields.io/cocoapods/l/Dependiject?color=blue
 [3]: https://img.shields.io/cocoapods/p/Dependiject?color=yellowgreen
 [4]: #documentation

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -28,7 +28,7 @@ fileprivate class TestObservable: ObservableObject, AnyObservableObject {
     var notPublished = 0
 }
 
-class StoreTests: XCTestCase {
+@MainActor class StoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         

--- a/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
+++ b/iOS 13 Example/Dependiject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -234,7 +234,7 @@
 				};
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "Dependiject" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -337,13 +337,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Example/Pods-Dependiject_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Dependiject/Dependiject.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Example/Pods-Dependiject_Example-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Dependiject.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Example/Pods-Dependiject_Example-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -355,15 +354,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Dependiject/Dependiject.framework",
-				"${BUILT_PRODUCTS_DIR}/MockingbirdFramework/Mockingbird.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Dependiject.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mockingbird.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Dependiject_Tests/Pods-Dependiject_Tests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/iOS 13 Example/Podfile.lock
+++ b/iOS 13 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 1d1fd0cfcd78e73ca4f418c80a6e53af91ea7aee
+  Dependiject: 72f82d59ffb0994b3fce3dfb891bbfada1dc3f69
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 69b53b587fc6c75eef571f57668f2e8e0e0ecf77

--- a/iOS 14 Example/Podfile.lock
+++ b/iOS 14 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 1d1fd0cfcd78e73ca4f418c80a6e53af91ea7aee
+  Dependiject: 72f82d59ffb0994b3fce3dfb891bbfada1dc3f69
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 36b8602ef54137bf035edec6b6d987f87e3dfa23


### PR DESCRIPTION
## Issue Link

Fixes #38

## Overview of Changes

This PR makes a slight adjustment to the `@Store` property wrapper to follow Swift's concurrency rules. However, this also requires Swift 5.5 or later, so both the code and documentation have been updated accordingly.

### Anything you want to highlight?

While the `nonisolated` keyword isn't strictly required, adding that with no other changes upgrades this problem from an opt-in warning to a guaranteed error.

I didn't enable the `-warn-concurrency` flag because it warns about accesses to `Factory.options`. ~~However, I left it commented-out in Package.swift, so you can easily un-comment it to enable the warning.~~

Edit: I will remove the comment from Package.swift. To enable the flag, add the following lines to the target:

```diff
         .target(
             name: "Dependiject",
             path: "Dependiject",
+            swiftSettings: [
+                .unsafeFlags([
+                    "-warn-concurrency"
+                ])
+            ],
             linkerSettings: [
                 .linkedFramework("SwiftUI"),
                 .linkedFramework("Combine")
             ]
         ),
```

## Test Plan

Enable the `-warn-concurrency` compiler flag. The Store should emit no warnings.