### PR TITLE
Fix documentation links

### DIFF
--- a/Dependiject/RegistrationBuilder.swift
+++ b/Dependiject/RegistrationBuilder.swift
@@ -6,9 +6,9 @@
 //  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
 //
 
-/// A result builder that collects [Registrations](dependiject/Registration) and
-/// [RegistrationConvertibles](dependiject/RegistrationConvertible), and produces a list of
-/// registrations usable by the factory.
+/// A result builder that collects [Registrations](/documentation/dependiject/registration) and
+/// [RegistrationConvertibles](/documentation/dependiject/registrationconvertible), and produces a
+/// list of registrations usable by the factory.
 ///
 /// This result builder is solely used for the ``Factory/register(builder:)`` method. See the
 /// documentation there for details.


### PR DESCRIPTION
## Issue Link

Fixes #43

## Overview of Changes

This PR fixes the documentation links to work from anywhere (hosted vs in Xcode, main page vs RegistrationBuilder page).

### Anything you want to highlight?

N/A

## Test Plan

Build the documentation and check the first two links from RegistrationBuilder.
