### PR TITLE
Make name argument labeled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ formatting guidelines.
 
 ## Unreleased
 
-### Breaking
+### Changed
 
-- `name` is now a labeled argument to `Service.init`, to better match `resolve`.
+- The `name` argument to `Service.init` is now a labeled argument, to better match `resolve`.
 
 ## [0.3.0] - 2022-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. See [Keep a Changelog] for
 formatting guidelines.
 
+## Unreleased
+
+### Breaking
+
+- `name` is now a labeled argument to `Service.init`, to better match `resolve`.
+
 ## [0.3.0] - 2022-10-03
 
 ### Fixed

--- a/Dependiject/RegistrationConvertible.swift
+++ b/Dependiject/RegistrationConvertible.swift
@@ -48,15 +48,15 @@ where Self: Registration {
 
 /// The different lifecycles for dependencies that are provided by default.
 ///
-/// This is meant to be used with ``Service/init(_:_:_:_:)``; each case describes a different way of
-/// determining when the callback should be called vs. when the previous return value should be
+/// This is meant to be used with ``Service/init(_:_:name:_:)``; each case describes a different way
+/// of determining when the callback should be called vs. when the previous return value should be
 /// re-used.
 public enum Scope {
     /// Call the provided callback every time the dependency is requested.
     case transient
     /// Create a lazy-loaded singleton, and re-use the same one for further requests.
     /// - Note: This scope is for singletons that are created by the callback. If the singleton is
-    /// created elsewhere, use ``Service/init(constant:_:_:)`` instead.
+    /// created elsewhere, use ``Service/init(constant:_:name:)`` instead.
     case singleton
     /// Re-use an existing instance if it exists, but do not hold onto an unused instance.
     /// - Important: This scope can only be used with classes and actors. Value types are not
@@ -82,7 +82,7 @@ public struct Service: RegistrationConvertible {
     public init<T>(
         _ scope: Scope,
         _ type: T.Type,
-        _ name: String? = nil,
+        name: String? = nil,
         _ callback: @escaping (Resolver) -> T
     ) {
         switch scope {
@@ -103,7 +103,7 @@ public struct Service: RegistrationConvertible {
     ///   to.
     ///   - name: The name to give the registration object. This can usually be `nil`; it is only
     ///   necessary when registering two different services of the same type.
-    public init<T>(constant: T, _ type: T.Type, _ name: String? = nil) {
+    public init<T>(constant: T, _ type: T.Type, name: String? = nil) {
         self.registration = ConstantRegistration(type, name, constant)
     }
 }

--- a/Tests/RegistrationNameTests.swift
+++ b/Tests/RegistrationNameTests.swift
@@ -20,9 +20,9 @@ class RegistrationNameTests: XCTestCase {
     func test_names_disambiguate() {
         // set up the dependency container
         Factory.register {
-            Service(constant: "unnamed", String.self, nil)
-            Service(constant: "named 1", String.self, "1")
-            Service(constant: "named 2", String.self, "2")
+            Service(constant: "unnamed", String.self, name: nil)
+            Service(constant: "named 1", String.self, name: "1")
+            Service(constant: "named 2", String.self, name: "2")
         }
         
         // ensure the default is unnamed

--- a/Tests/ScopeTests.swift
+++ b/Tests/ScopeTests.swift
@@ -179,7 +179,7 @@ class ScopeTests: XCTestCase {
         )
     }
     
-    /// Test that `Service(constant:_:_:)` allows value types.
+    /// Test that `Service(constant:_:name:)` allows value types.
     func test_constant_allowsStructs() {
         // set up the dependency container
         Factory.register {


### PR DESCRIPTION
## Issue Link

Fixes #39

## Overview of Changes

This PR makes the `name` argument to the Service initializer require a label, to better match the resolve function.

### Anything you want to highlight?

N/A

## Test Plan

N/A