### PR TITLE
Add xcpretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ formatting guidelines.
 
 ### Changed
 
+- The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.
 - The `name` argument to `Service.init` is now a labeled argument, to better match `resolve`.
 
 ## [0.3.0] - 2022-10-03

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+ruby '>= 2.3.3'
+
+source 'https://rubygems.org'
+
+gem 'xcpretty', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rouge (2.0.7)
+    xcpretty (0.3.0)
+      rouge (~> 2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  xcpretty (~> 0.3)
+
+RUBY VERSION
+   ruby 2.6.8p205
+
+BUNDLED WITH
+   1.17.2

--- a/dochost.sh
+++ b/dochost.sh
@@ -7,11 +7,12 @@
 #  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
 #
 
-set -e
+set -eo pipefail
 cd "iOS 13 Example"
 pod install
 cd ..
-xcodebuild docbuild
+which xcpretty &>/dev/null || bundle install
+xcodebuild docbuild | xcpretty
 cd docserver
 yarn
 node index.js

--- a/runtests.sh
+++ b/runtests.sh
@@ -24,12 +24,16 @@ swift test || {
     return $exitCode
 }
 
+which xcpretty &>/dev/null || bundle install
+
 cd "iOS 13 Example"
 pod install
 xcodebuild -workspace Dependiject.xcworkspace -scheme Dependiject_Example -destination \
-    "id=$deviceId" test
+    "id=$deviceId" test | xcpretty
 
 cd "../iOS 14 Example"
 pod install
 xcodebuild -workspace Dependiject_Example.xcworkspace -scheme Dependiject_Example -destination \
-    "id=$deviceId" test
+    "id=$deviceId" test | xcpretty
+
+printf '\n\e[1m** TEST SUCCEEDED **\e[m\n\n'


### PR DESCRIPTION
## Issue Link

Fixes #50

## Overview of Changes

This PR adds a dependency on xcpretty, and pipes the output of `xcodebuild` to that.

### Anything you want to highlight?

If you don't already have xcpretty installed, the test and documentation scripts automatically install it. This may require you to enter your password into the terminal.

## Test Plan

Run the test or documentation script and note the significantly reduced output:

```zsh
% ./runtests.sh 2>&1 | wc                     
     115     683    7913
```
That is, it outputs 115 lines; 683 words; 7913 bytes. Compare this to the count in the linked issue.
