### PR TITLE
Add clearDependencies method to Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ formatting guidelines.
 
 ### Added
 
+- The factory now has a `clearDependencies()` method intended for testing.
 - Singletons which depend on weak services now trigger an assertion failure by default.
 
 ### Changed

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -143,6 +143,19 @@ public final class Factory: SingletonCheckingResolver, @unchecked Sendable {
         shared.lock.unlock()
     }
     
+    /// Resets the factory, clearing all dependencies.
+    ///
+    /// This is mostly meant for testing; you could call this from your test class's `setUp()` or
+    /// `setUpWithError()` method.
+    public static func clearDependencies() {
+        shared.lock.lock()
+        
+        assert(shared.resolutionDepth == 0, "Cannot reset dependencies while resolving.")
+        shared.registrations = []
+        
+        shared.lock.unlock()
+    }
+    
     public func resolve<T>(_ type: T.Type, name: String?) -> T {
         lock.lock()
         defer {

--- a/Tests/BaseFactoryTest.swift
+++ b/Tests/BaseFactoryTest.swift
@@ -1,0 +1,20 @@
+//
+//  BaseFactoryTest.swift
+//  
+//
+//  Created by William Baker on 10/6/22.
+//
+
+import XCTest
+@testable import Dependiject
+
+/// The base class for tests that use the factory.
+class BaseFactoryTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        self.continueAfterFailure = false
+        
+        Factory.clearDependencies()
+    }
+}

--- a/Tests/DuplicateRegistrationTest.swift
+++ b/Tests/DuplicateRegistrationTest.swift
@@ -9,13 +9,7 @@
 import XCTest
 @testable import Dependiject
 
-class DuplicateRegistrationTest: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        self.continueAfterFailure = false
-    }
-    
+final class DuplicateRegistrationTest: BaseFactoryTest {
     /// Test that later registrations override earlier ones when they conflict.
     func test_duplicateRegistration_laterOverridesEarlier() {
         // set up the dependency container more than once

--- a/Tests/MultitypeServiceTests.swift
+++ b/Tests/MultitypeServiceTests.swift
@@ -14,13 +14,7 @@ fileprivate protocol P1: AnyObject {}
 fileprivate protocol P2: AnyObject {}
 fileprivate class C: P1, P2 {}
 
-class MultitypeServiceTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        self.continueAfterFailure = false
-    }
-    
+final class MultitypeServiceTests: BaseFactoryTest {
     /// Test that the exposed types both resolve the same instance.
     func test_multitypeServiceClosure_typesResolveSame() {
         // set up the dependency container

--- a/Tests/ParallelResolutionTest.swift
+++ b/Tests/ParallelResolutionTest.swift
@@ -11,13 +11,7 @@ import XCTest
 
 fileprivate class C {}
 
-class ParallelResolutionTest: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        self.continueAfterFailure = false
-    }
-    
+final class ParallelResolutionTest: BaseFactoryTest {
     func test_parallelResolutions() {
         Factory.register {
             // test both of the stateful registration types

--- a/Tests/RegistrationNameTests.swift
+++ b/Tests/RegistrationNameTests.swift
@@ -9,13 +9,7 @@
 import XCTest
 @testable import Dependiject
 
-class RegistrationNameTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        
-        self.continueAfterFailure = false
-    }
-    
+final class RegistrationNameTests: BaseFactoryTest {
     /// Test that dependency names are handled correctly.
     func test_names_disambiguate() {
         // set up the dependency container

--- a/Tests/ScopeTests.swift
+++ b/Tests/ScopeTests.swift
@@ -26,12 +26,11 @@ fileprivate class DependsOnClass {
     }
 }
 
-class ScopeTests: XCTestCase {
-    /// Reset the counter between tests, and disable continue-on-failure.
+final class ScopeTests: BaseFactoryTest {
+    /// Reset the counter between tests.
     override func setUp() {
         super.setUp()
         
-        self.continueAfterFailure = false
         ConstructorCounter.count = 0
     }
     

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -28,7 +28,7 @@ fileprivate class TestObservable: ObservableObject, AnyObservableObject {
     var notPublished = 0
 }
 
-@MainActor class StoreTests: XCTestCase {
+@MainActor final class StoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         

--- a/iOS 13 Example/Tests/PrimaryViewModelTests.swift
+++ b/iOS 13 Example/Tests/PrimaryViewModelTests.swift
@@ -35,6 +35,7 @@ class PrimaryViewModelTests: XCTestCase {
          * -- so I'm using the factory here to demonstrate that it is possible.
          */
         
+        Factory.clearDependencies()
         Factory.register {
             Service(constant: self.mockFetcher, DataFetcher.self)
             

--- a/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
+++ b/iOS 14 Example/Dependiject_ExampleTests/PrimaryViewModelTests.swift
@@ -35,6 +35,7 @@ class PrimaryViewModelTests: XCTestCase {
          * -- so I'm using the factory here to demonstrate that it is possible.
          */
         
+        Factory.clearDependencies()
         Factory.register {
             Service(constant: self.mockFetcher, DataFetcher.self)
             


### PR DESCRIPTION
## Issue Link

Fixes #52

## Overview of Changes

This PR adds a static method `clearDependencies()` to the factory, and calls it at the start of each test that uses the factory.

### Anything you want to highlight?

N/A

## Test Plan

Checking the factory's `registrations` array at the start of a test (e.g. with a breakpoint) should always show an empty array. On master, it is not empty if another test method has already been called as part of the same test run (e.g. running the whole test class rather than just one test method).
