### PR TITLE
Fix unhelpful type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ formatting guidelines.
 
 ### Fixed
 
+- Extraneous arguments in Service callbacks will now be properly diagnosed.
 - The `@Store` property wrapper now follows Swift's concurrency rules.
 
 ### Added

--- a/Dependiject/Resolver.swift
+++ b/Dependiject/Resolver.swift
@@ -41,6 +41,9 @@ public extension Resolver {
     /// Without this overload, adding extraneous arguments to an `init` inside of the callback
     /// passed to ``Service/init(_:_:name:_:)`` does not error at the `init` call, but at the top
     /// of the ``Factory/register(builder:)`` block.
+    ///
+    /// - Remark: This overload does not show up in the documentation because it is explicitly
+    /// marked `unavailable`.
     @available(*, unavailable, renamed: "resolve(_:name:)", message: """
         If this is being called, Swift cannot determine the correct type.
         """)

--- a/Dependiject/Resolver.swift
+++ b/Dependiject/Resolver.swift
@@ -44,8 +44,8 @@ public extension Resolver {
     ///
     /// - Remark: This overload does not show up in the documentation because it is explicitly
     /// marked `unavailable`.
-    @available(*, unavailable, renamed: "resolve(_:name:)", message: """
-        If this is being called, Swift cannot determine the correct type.
+    @available(*, unavailable, message: """
+        Could not determine expected type. Explicitly specify with resolve(_:) or resolve(_:name:).
         """)
     func resolve(name: String? = nil) -> Any {
         preconditionFailure("Could not determine type to resolve.")

--- a/Dependiject/Resolver.swift
+++ b/Dependiject/Resolver.swift
@@ -19,7 +19,7 @@ public extension Resolver {
     /// Get an unnamed dependency of the specified type.
     /// - Returns: The unnamed instance of the type.
     /// - Important: There must be an unnamed registration of the specified type. When resolving a
-    /// named dependency, use ``resolve(_:name:)`` or ``resolve(name:)`` instead.
+    /// named dependency, use ``resolve(_:name:)`` or ``Resolver/resolve(name:)`` instead.
     func resolve<T>(_ type: T.Type) -> T {
         return self.resolve(type, name: nil)
     }
@@ -32,5 +32,19 @@ public extension Resolver {
     /// ``resolve(_:name:)`` or ``resolve(_:)`` instead (which take the type as a parameter).
     func resolve<T>(name: String? = nil) -> T {
         return self.resolve(T.self, name: name)
+    }
+    
+    /// This overload fixes compiler errors.
+    ///
+    /// To explicitly specify the type, use ``resolve(_:name:)`` or ``resolve(_:)`` instead.
+    ///
+    /// Without this overload, adding extraneous arguments to an `init` inside of the callback
+    /// passed to ``Service/init(_:_:name:_:)`` does not error at the `init` call, but at the top
+    /// of the ``Factory/register(builder:)`` block.
+    @available(*, unavailable, renamed: "resolve(_:name:)", message: """
+        If this is being called, Swift cannot determine the correct type.
+        """)
+    func resolve(name: String? = nil) -> Any {
+        preconditionFailure("Could not determine type to resolve.")
     }
 }


### PR DESCRIPTION
## Issue Link

Fixes #54 

Jira issue: [THOS-5](https://tinyhomeconsultingllc.atlassian.net/browse/THOS-5)

## Overview of Changes

This PR fixes type resolution errors. Basically, what would happen in a situation like this:

```swift
protocol P {}
class C: P {
    init(a: Int, c: String) {}
}

func setup() {
    Factory.register { // [1]
        Service(.transient, P.self) { r in
            C(
                a: r.resolve(),
                b: r.resolve(), // [2]
                c: r.resolve()
            )
        }
    }
}
```

is that Swift would be unable to figure out the generic type argument to `r.resolve()` at [2], since the initializer for `C` doesn't take a `b`. Because it can't determine the return type, swift would report "type of expression is ambiguous without more context", completely ignoring the fact that it's not meant to be there. Due to the result builder transform, the error would be reported at [1] instead of [2].

Adding an overload that returns `Any` works around this problem: if it can't figure out how to call `resolve<T>() -> T`, it tries the other overload, `resolve() -> Any`. This allows it to complete type-checking and realize that `b` shouldn't even be there.

### Anything you want to highlight?

I marked the overload as `@available(*, unavailable)`. This has two consequences:

1. In a line like `var x: Any = Factory.shared.resolve()`, this is inferred as `resolve<Any>()` instead of the new overload.
2. A line with no types at all, such as `var x = Factory.shared.resolve()`, still emits an error: 
<img width="1180" alt="Screen Shot 2022-10-13 at 9 56 12 AM" src="https://user-images.githubusercontent.com/25109429/195616871-bace1fe1-55ea-4ab8-86a4-76b9329a54c2.png">

However, it has the downside that the new overload doesn't show up in the documentation. Using `deprecated` instead of `unavailable` makes it show up in the documentation, but also makes point 1 no longer true, and downgrades point 2 from an error to a warning.

## Test Plan

Paste the code snippet above (or any equivalent) into a project that imports Dependiject. You should see the error at [2] instead of [1].
