### PR TITLE
Bump required CocoaPods version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ formatting guidelines.
 
 ### Removed
 
+- Dropped support for CocoaPods &lt; 1.11.3.
 - Dropped support for Swift &lt; 5.5 (Xcode &lt; 13.2).
 
 ### Fixed

--- a/Dependiject.podspec
+++ b/Dependiject.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
     s.watchos.deployment_target = '6.0'
     s.tvos.deployment_target = '13.0'
     
-    s.cocoapods_version = '~> 1.10'
+    s.cocoapods_version = '>= 1.11.3'
     s.swift_versions = '5.5'
     s.source_files = 'Dependiject/**/*.swift'
     

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>= 2.3.3'
+ruby '>= 2.6'
 
 source 'https://rubygems.org'
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,12 @@ struct SomeView: View {
 To use this library requires Xcode 13.2 / Swift 5.5 or later. Dependiject is supported for all
 platforms that support SwiftUI.
 
-To install the library with CocoaPods requires version 1.10.0 or later, but we recommend using
-version 1.11.0 or later.
+To install the library with CocoaPods requires version 1.11.3 or later.
 
-To run the tests from the command line (see [Automated Tests][9] below) requires CocoaPods 1.11.3
-and NodeJS 6 or later.
+To run the tests from the command line (see [Automated Tests][9] below) requires NodeJS 6 or later.
 
-To host the documentation locally (see [Documentation][4] below) requires CocoaPods 1.11.3 and
-NodeJS 12 or later, and expects yarn to be installed globally.
+To host the documentation locally (see [Documentation][4] below) requires NodeJS 12 or later, and
+expects yarn to be installed globally.
 
 ## Installation
 

--- a/iOS 13 Example/Podfile.lock
+++ b/iOS 13 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 72f82d59ffb0994b3fce3dfb891bbfada1dc3f69
+  Dependiject: 5ae7d97714c3ab3a4ffe0a33e4f71a3e91966ea2
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 69b53b587fc6c75eef571f57668f2e8e0e0ecf77

--- a/iOS 14 Example/Podfile.lock
+++ b/iOS 14 Example/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 72f82d59ffb0994b3fce3dfb891bbfada1dc3f69
+  Dependiject: 5ae7d97714c3ab3a4ffe0a33e4f71a3e91966ea2
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 36b8602ef54137bf035edec6b6d987f87e3dfa23


### PR DESCRIPTION
## Issue Link

Fixes #57

Jira issue: https://tinyhomeconsultingllc.atlassian.net/browse/THOS-6

## Overview of Changes

This PR bumps the required CocoaPods version from 1.10.0 to 1.11.3.

### Anything you want to highlight?

N/A

## Test Plan

N/A
