### PR TITLE
store-schedule-dispatch-main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ formatting guidelines.
 
 ### Changed
 
+- `@Store` now publishes changes on `DispatchQueue.main` by default, rather than `RunLoop.main`.
 - The default options are now reflected in the initializer for `ResolutionOptions`.
 - The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.
 - The `name` argument to `Service.init` is now a labeled argument, to better match `resolve`.

--- a/Dependiject/Store.swift
+++ b/Dependiject/Store.swift
@@ -67,7 +67,7 @@ public struct Store<ObjectType> {
     
     /// Create a stored value on a custom scheduler.
     ///
-    /// Use this init to schedule updates on a specific scheduler other than `RunLoop.main`.
+    /// Use this init to schedule updates on a specific scheduler other than `DispatchQueue.main`.
     public init<S: Scheduler>(
         wrappedValue: ObjectType,
         on scheduler: S,
@@ -92,7 +92,7 @@ public struct Store<ObjectType> {
     ///
     /// To control when updates are published, see ``init(wrappedValue:on:schedulerOptions:)``.
     public init(wrappedValue: ObjectType) {
-        self.init(wrappedValue: wrappedValue, on: RunLoop.main)
+        self.init(wrappedValue: wrappedValue, on: DispatchQueue.main)
     }
     
     /// An equivalent to SwiftUI's


### PR DESCRIPTION
## Issue Link
Fixes #62 
https://tinyhomeconsultingllc.atlassian.net/browse/THOS-14

## Overview of Changes
Changes the default scheduler for the `@Store` property wrapper from `RunLoop.main` to `DispatchQueue.main`.

### Anything you want to highlight?
It's a smaller PR but let me know if I failed to update all the necessary documentation etc.

## Test Plan

The example apps will work almost exactly the same. On a smaller device, you may be to manipulate the scroll view to see the difference between button actions while it's scrolling. But really, it's cases like the one linked in the issue that this matters the most for.
