### PR TITLE
Restrict access to factory options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ formatting guidelines.
 
 ### Changed
 
+- The factory's options cannot be accessed directly; instead, use the static methods `getOptions()`
+  and `updateOptions(mutation:)`.
 - `@Store` now publishes changes on `DispatchQueue.main` by default, rather than `RunLoop.main`.
 - The default options are now reflected in the initializer for `ResolutionOptions`.
 - The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.

--- a/Dependiject/Registration.swift
+++ b/Dependiject/Registration.swift
@@ -66,7 +66,7 @@ internal class WeakRegistration: Registration {
     
     internal func resolve(_ resolver: Resolver) -> Any {
         if let resolver = resolver as? SingletonCheckingResolver {
-            let options = Factory.options
+            let options = Factory.getOptions()
             enforceCondition(
                 options.mode,
                 options.singletonAcceptsWeak || !resolver.isResolvingForSingleton(),

--- a/Tests/ParallelResolutionTest.swift
+++ b/Tests/ParallelResolutionTest.swift
@@ -24,4 +24,18 @@ final class ParallelResolutionTest: BaseFactoryTest {
             _ = Factory.shared.resolve(Int.self)
         }
     }
+    
+    func test_parallelOptionsMutation_isAtomic() {
+        Factory.updateOptions { options in
+            options.maxDepth = 100
+        }
+        
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            Factory.updateOptions { options in
+                options.maxDepth += 1
+            }
+        }
+        
+        XCTAssertEqual(Factory.getOptions().maxDepth, 200, "Increments should be atomic")
+    }
 }

--- a/Tests/ScopeTests.swift
+++ b/Tests/ScopeTests.swift
@@ -200,7 +200,9 @@ final class ScopeTests: BaseFactoryTest {
     /// Test that the options allow you to override singleton-requires-weak errors.
     func test_factoryOptions_allowSingletonResolvingWeak() {
         // set the options
-        Factory.options.singletonAcceptsWeak = true
+        Factory.updateOptions { options in
+            options.singletonAcceptsWeak = true
+        }
         
         // set up the dependency container
         Factory.register {


### PR DESCRIPTION
## Issue Link

Fixes #65 

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-17

## Overview of Changes

This PR changes how the factory's options can be accessed, allowing for better control and thread-safety.

### Anything you want to highlight?

N/A

## Test Plan

See the new test for mutating the options concurrently. Previously, these were implemented as pairs of get/set operations, and if these operations were interleaved, the total result at the end would be less than expected.
