### PR TITLE
Change MultitypeService.Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ formatting guidelines.
 
 - The factory's options cannot be accessed directly; instead, use the static methods `getOptions()`
   and `updateOptions(mutation:)`.
+- `MultitypeService.Iterator` is now an alias for `AnyIterator<Registration>`, not
+  `IndexingIterator<[Registration]>`.
 - `@Store` now publishes changes on `DispatchQueue.main` by default, rather than `RunLoop.main`.
 - The default options are now reflected in the initializer for `ResolutionOptions`.
 - The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ formatting guidelines.
 
 ### Changed
 
-- The factory's options cannot be accessed directly; instead, use the static methods `getOptions()`
-  and `updateOptions(mutation:)`.
 - `MultitypeService.Iterator` is now an alias for `AnyIterator<Registration>`, not
   `IndexingIterator<[Registration]>`.
+- The factory's options cannot be accessed directly; instead, use the static methods `getOptions()`
+  and `updateOptions(mutation:)`.
 - `@Store` now publishes changes on `DispatchQueue.main` by default, rather than `RunLoop.main`.
 - The default options are now reflected in the initializer for `ResolutionOptions`.
 - The test and documentation scripts now use `xcpretty` to clean up `xcodebuild` output.

--- a/Dependiject/MultitypeService.swift
+++ b/Dependiject/MultitypeService.swift
@@ -73,7 +73,7 @@ public struct MultitypeService<T: AnyObject> {
 
 extension MultitypeService: Sequence {
     public typealias Element = Registration
-    public typealias Iterator = Array<Registration>.Iterator
+    public typealias Iterator = AnyIterator<Registration>
     
     public var underestimatedCount: Int {
         // no need to underestimate, we know the count
@@ -106,6 +106,6 @@ extension MultitypeService: Sequence {
             }
         } + CollectionOfOne(baseRegistration)
         
-        return arr.makeIterator()
+        return AnyIterator(arr.makeIterator())
     }
 }


### PR DESCRIPTION
## Issue Link

Fixes #66

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-18

## Overview of Changes

This PR changes the public-facing iterator type from `IndexingIterator` to `AnyIterator`.

### Anything you want to highlight?

N/A

## Test Plan

N/A
