### PR TITLE
Wrap Scope enum in struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ formatting guidelines.
 
 ### Changed
 
+- Switching over `Scope` now requires a `default:` branch.
 - `MultitypeService.Iterator` is now an alias for `AnyIterator<Registration>`, not
   `IndexingIterator<[Registration]>`.
 - The factory's options cannot be accessed directly; instead, use the static methods `getOptions()`

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -13,6 +13,9 @@ import Foundation
 /// This is used by the ``Factory`` for sanity checks, such as detecting circular dependencies and
 /// validating scopes.
 public enum ErrorCheckMode: Sendable, Hashable {
+    // Adding more cases to this enum is a breaking change that can only happen for major releases;
+    // see https://github.com/Tiny-Home-Consulting/Dependiject/issues/67 for an explanation.
+    
     /// Never perform any error checking.
     case never
     /// Error check using

--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// This is used by the ``Factory`` for sanity checks, such as detecting circular dependencies and
 /// validating scopes.
-public enum ErrorCheckMode: Sendable {
+public enum ErrorCheckMode: Sendable, Hashable {
     /// Never perform any error checking.
     case never
     /// Error check using

--- a/Dependiject/RegistrationConvertible.swift
+++ b/Dependiject/RegistrationConvertible.swift
@@ -51,17 +51,25 @@ where Self: Registration {
 /// This is meant to be used with ``Service/init(_:_:name:_:)``; each case describes a different way
 /// of determining when the callback should be called vs. when the previous return value should be
 /// re-used.
-public enum Scope {
+public struct Scope: Equatable {
+    internal let value: UnderlyingType
+    
     /// Call the provided callback every time the dependency is requested.
-    case transient
+    public static let transient = Scope(value: .transient)
     /// Create a lazy-loaded singleton, and re-use the same one for further requests.
     /// - Note: This scope is for singletons that are created by the callback. If the singleton is
     /// created elsewhere, use ``Service/init(constant:_:name:)`` instead.
-    case singleton
+    public static let singleton = Scope(value: .singleton)
     /// Re-use an existing instance if it exists, but do not hold onto an unused instance.
     /// - Important: This scope can only be used with classes and actors. Value types are not
     /// allowed to be registered weakly.
-    case weak
+    public static let weak = Scope(value: .weak)
+    
+    internal enum UnderlyingType: Equatable {
+        case transient
+        case singleton
+        case weak
+    }
 }
 
 /// A wrapper around a `Registration` object, intended for use with ``Factory/register(builder:)``.
@@ -85,7 +93,7 @@ public struct Service: RegistrationConvertible {
         name: String? = nil,
         _ callback: @escaping (Resolver) -> T
     ) {
-        switch scope {
+        switch scope.value {
         case .transient:
             self.registration = TransientRegistration(type, name, callback)
         case .singleton:


### PR DESCRIPTION
## Issue Link

Fixes #67

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-19

## Overview of Changes

This PR wraps the `Scope` enum in a struct, so that adding new cases is not a breaking change.

### Anything you want to highlight?

`ErrorCheckMode` was implicitly hashable, I just made it explicit.

## Test Plan

Switch over a variable typed `Scope`. You should be allowed to have `case .weak`, `case .transient`, and `case .singleton` branches, but required to have a `default` branch.