### PR TITLE
Add Resolver to Factory's protocol list

### DIFF
--- a/Dependiject/Factory.swift
+++ b/Dependiject/Factory.swift
@@ -91,7 +91,7 @@ internal protocol SingletonCheckingResolver: Resolver {
 }
 
 /// The class to which you register dependencies.
-public final class Factory: SingletonCheckingResolver, @unchecked Sendable {
+public final class Factory: SingletonCheckingResolver, Resolver, @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var registrations: [Registration] = []
     private var resolutionDepth: UInt = 0


### PR DESCRIPTION
## Issue Link

Fixes #71

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-20

## Overview of Changes

This PR adds `Resolver` to the list of protocols adopted by `Factory`, so that it is visible even when the internal protocol is not.

### Anything you want to highlight?

This doesn't require a changelog entry, since the thing it changes was never present in an actual release.

## Test Plan

- If you have the autogenerated header open from another branch, close it and clean the build folder.
- Rebuild the test/example project you used to see the autogenerated header.
- Open the autogenerated header again. It should now say:
  ```swift
  final public class Factory : Dependiject.Resolver, @unchecked Sendable {
  ```