### PR TITLE
Named multitype service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ formatting guidelines.
 
 ### Added
 
+- MultitypeService now supports named dependencies.
 - `Resolver` now has a new requirement, `resolveAll(_:)`, which gives a mapping of name -> instance
   for all dependencies of a given type.
 - The factory now has a `clearDependencies()` method intended for testing.

--- a/Dependiject/MultitypeService.swift
+++ b/Dependiject/MultitypeService.swift
@@ -31,12 +31,14 @@ internal enum RegistrationTypeList {
         switch self {
         case .sharedName(let arr, let name):
             if arr.contains(where: { $0 == type }) {
-                return name
+                return .some(name)
             }
-            return .none // as opposed to .some(nil)
         case .individualNames(let kvp):
-            return kvp.last { $0.key == type }?.value
+            if let last = kvp.last(where: { $0.key == type }) {
+                return .some(last.value)
+            }
         }
+        return .none
     }
     
     internal func map<T>(_ transform: (Any.Type, String?) throws -> T) rethrows -> [T] {

--- a/Dependiject/MultitypeService.swift
+++ b/Dependiject/MultitypeService.swift
@@ -137,8 +137,8 @@ extension RegistrationTypeList: TextOutputStreamable {
 /// let myStateUpdater = Factory.shared.resolve(StateUpdater.self, name: "MyStateUpdater")
 /// ```
 public struct MultitypeService<T: AnyObject> {
-    fileprivate let exposedTypes: RegistrationTypeList
-    fileprivate let getInstance: MultitypeRegistrationType<T>
+    private let exposedTypes: RegistrationTypeList
+    private let getInstance: MultitypeRegistrationType<T>
     
     /// Create a registration exposed under multiple protocols.
     /// - Parameters:

--- a/Dependiject/MultitypeService.swift
+++ b/Dependiject/MultitypeService.swift
@@ -177,8 +177,8 @@ public struct MultitypeService<T: AnyObject> {
     
     /// Create a registration exposed under multiple protocols.
     /// - Parameters:
-    ///   - interfaces: A map of the types this is exposed as, and the name associated with each
-    ///   type.
+    ///   - interfaces: A map of the types this service is exposed as, and the name associated with
+    ///   each type.
     ///   - callback: The callback to use to create the shared instance of the dependency.
     /// - Important: The return type of the callback must be a subtype of every key of the
     /// `interfaces` dictionary. If this is not the case, attempting to resolve the instance will
@@ -193,8 +193,8 @@ public struct MultitypeService<T: AnyObject> {
     
     /// Create a registration exposed under multiple protocols.
     /// - Parameters:
-    ///   - interfaces: A map of the types this is exposed as, and the name associated with each
-    ///   type.
+    ///   - interfaces: A map of the types this service is exposed as, and the name associated with
+    ///   each type.
     ///   - value: The shared instance of the dependency.
     /// - Important: The return type of the callback must be a subtype of every key of the
     /// `interfaces` dictionary. If this is not the case, attempting to resolve the instance will

--- a/Tests/MultitypeServiceTests.swift
+++ b/Tests/MultitypeServiceTests.swift
@@ -33,7 +33,7 @@ final class MultitypeServiceTests: BaseFactoryTest {
     
     /// Test that the original class is hidden by default (i.e. it's registered with an internal
     /// name the caller may not know, rather than being nameless).
-    func test_multitypeServiceClosure_hidesOriginal() {
+    func test_multitypeServiceClosureArray_hidesOriginal() {
         // Because `resolve()` causes a preconditionFailure when no matches are found, we can't use
         // the factory here. Instead, we have to inspect the `MultitypeService` object itself.
         
@@ -49,6 +49,25 @@ final class MultitypeServiceTests: BaseFactoryTest {
             XCTAssertFalse(
                 registration.type == C.self && registration.name == nil,
                 "Original type should be hidden but was found with no name"
+            )
+        }
+    }
+    
+    func test_multitypeServiceClosureDictionary_hidesOriginal() {
+        let service = MultitypeService(exposedAs: [P1.self: "a", P2.self: "b"]) { _ in
+            C()
+        }
+        
+        // Iterating should reveal, in order:
+        // { type: P1.self, name: "a" }
+        // { type: P2.self, name: "b" }
+        // { type: C.self, name: <some internal name that isn't nil, "a", or "b"> }
+        let invalidNames: Set<String?> = ["a", "b", nil]
+        for registration in service {
+            let name = registration.name
+            XCTAssertFalse(
+                registration.type == C.self && invalidNames.contains(name),
+                "Original type should be hidden but was found with name \(name?.debugDescription ?? "nil")"
             )
         }
     }
@@ -91,7 +110,7 @@ final class MultitypeServiceTests: BaseFactoryTest {
         _ = Factory.shared.resolve(C.self)
     }
     
-    func test_multitypeServiceConstant_hidesOriginal() {
+    func test_multitypeServiceConstantArray_hidesOriginal() {
         // Because `resolve()` causes a preconditionFailure when no matches are found, we can't use
         // the factory here. Instead, we have to inspect the `MultitypeService` object itself.
         
@@ -105,6 +124,23 @@ final class MultitypeServiceTests: BaseFactoryTest {
             XCTAssertFalse(
                 registration.type == C.self && registration.name == nil,
                 "Original type should be hidden but was found with no name"
+            )
+        }
+    }
+    
+    func test_multitypeServiceConstantDictionary_hidesOriginal() {
+        let service = MultitypeService(exposedAs: [P1.self: "a", P2.self: "b"], C())
+        
+        // Iterating should reveal, in order:
+        // { type: P1.self, name: "a" }
+        // { type: P2.self, name: "b" }
+        // { type: C.self, name: <some internal name that isn't nil, "a", or "b"> }
+        let invalidNames: Set<String?> = ["a", "b", nil]
+        for registration in service {
+            let name = registration.name
+            XCTAssertFalse(
+                registration.type == C.self && invalidNames.contains(name),
+                "Original type should be hidden but was found with name \(name?.debugDescription ?? "nil")"
             )
         }
     }
@@ -149,20 +185,29 @@ final class MultitypeServiceTests: BaseFactoryTest {
         _ = Factory.shared.resolve(C.self, name: "class")
     }
     
-    func test_multitypeServiceConstant_individualNamesStaySeparate() {
+    func test_multitypeServiceClosureDictionary_originalNamedNilDoesntUseHiddenName() {
         Factory.register {
-            MultitypeService(
-                exposedAs: [
-                    P1.self: "protocol 1",
-                    P2.self: "protocol 2",
-                    C.self: "class"
-                ],
+            MultitypeService(exposedAs: [C.self: nil]) { _ in
                 C()
-            )
+            }
         }
         
-        _ = Factory.shared.resolve(P1.self, name: "protocol 1")
-        _ = Factory.shared.resolve(P2.self, name: "protocol 2")
-        _ = Factory.shared.resolve(C.self, name: "class")
+        let resolveCount = Factory.shared.resolveAll(C.self).count
+        XCTAssertEqual(
+            resolveCount, 1,
+            "C should have 1 registration but found \(resolveCount)"
+        )
+    }
+    
+    func test_multitypeServiceConstant_individualNamesAllowNil() {
+        Factory.register {
+            MultitypeService( exposedAs: [C.self: nil], C())
+        }
+        
+        let resolveCount = Factory.shared.resolveAll(C.self).count
+        XCTAssertEqual(
+            resolveCount, 1,
+            "C should have 1 registration but found \(resolveCount)"
+        )
     }
 }

--- a/Tests/MultitypeServiceTests.swift
+++ b/Tests/MultitypeServiceTests.swift
@@ -201,7 +201,7 @@ final class MultitypeServiceTests: BaseFactoryTest {
     
     func test_multitypeServiceConstant_individualNamesAllowNil() {
         Factory.register {
-            MultitypeService( exposedAs: [C.self: nil], C())
+            MultitypeService(exposedAs: [C.self: nil], C())
         }
         
         let resolveCount = Factory.shared.resolveAll(C.self).count

--- a/Tests/MultitypeServiceTests.swift
+++ b/Tests/MultitypeServiceTests.swift
@@ -108,4 +108,61 @@ final class MultitypeServiceTests: BaseFactoryTest {
             )
         }
     }
+    
+    func test_multitypeServiceClosure_sharedNameResolves() {
+        Factory.register {
+            MultitypeService(exposedAs: [P1.self, P2.self], name: "test name") { _ in
+                C()
+            }
+        }
+        
+        let p1Instance = Factory.shared.resolve(P1.self, name: "test name")
+        let p2Instance = Factory.shared.resolve(P2.self, name: "test name")
+        
+        XCTAssertIdentical(p1Instance, p2Instance, "Both protocols should give the same instance")
+    }
+    
+    func test_multitypeServiceConstant_sharedNameResolves() {
+        Factory.register {
+            MultitypeService(exposedAs: [P1.self, P2.self], name: "test name", C())
+        }
+        
+        let p1Instance = Factory.shared.resolve(P1.self, name: "test name")
+        let p2Instance = Factory.shared.resolve(P2.self, name: "test name")
+        
+        XCTAssertIdentical(p1Instance, p2Instance, "Both protocols should give the same instance")
+    }
+    
+    func test_multitypeServiceClosure_individualNamesStaySeparate() {
+        Factory.register {
+            MultitypeService(exposedAs: [
+                P1.self: "protocol 1",
+                P2.self: "protocol 2",
+                C.self: "class"
+            ]) { _ in
+                C()
+            }
+        }
+        
+        _ = Factory.shared.resolve(P1.self, name: "protocol 1")
+        _ = Factory.shared.resolve(P2.self, name: "protocol 2")
+        _ = Factory.shared.resolve(C.self, name: "class")
+    }
+    
+    func test_multitypeServiceConstant_individualNamesStaySeparate() {
+        Factory.register {
+            MultitypeService(
+                exposedAs: [
+                    P1.self: "protocol 1",
+                    P2.self: "protocol 2",
+                    C.self: "class"
+                ],
+                C()
+            )
+        }
+        
+        _ = Factory.shared.resolve(P1.self, name: "protocol 1")
+        _ = Factory.shared.resolve(P2.self, name: "protocol 2")
+        _ = Factory.shared.resolve(C.self, name: "class")
+    }
 }


### PR DESCRIPTION
## Issue Link

Fixes #56

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-21

## Overview of Changes

This PR adds the ability to give names to dependencies that are registered with `MultitypeService`.

### Anything you want to highlight?

I don't like that `RegistrationTypeList.getName(for:)` returns an optional of an optional, but I'm not sure what more idiomatic return type there would be. It's on an `internal func` at least, so it's not public API.

## Test Plan

Register and resolve named and unnamed dependencies that are created under `MultitypeService`. If the array/dictionary passed to the init doesn't list a certain type, you shouldn't be able to resolve the object as that type even if the type matches at runtime.
