### PR TITLE
Add resolveAll() to Resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ formatting guidelines.
 
 ### Added
 
+- `Resolver` now has a new requirement, `resolveAll(_:)`, which gives a mapping of name -> instance
+  for all dependencies of a given type.
 - The factory now has a `clearDependencies()` method intended for testing.
 - Singletons which depend on weak services now trigger an assertion failure by default.
 

--- a/Dependiject/Resolver.swift
+++ b/Dependiject/Resolver.swift
@@ -13,6 +13,14 @@ public protocol Resolver {
     /// - Precondition: A registration with the given type and name exists.
     /// - Returns: The instance of the type with the given name.
     func resolve<T>(_ type: T.Type, name: String?) -> T
+    /// Get all dependencies of the specified type which have unique names.
+    ///
+    /// As with ``resolve(_:name:)``, this does not consider registrations with the same type and
+    /// name to be distinct. This fetches only things that can be found with that method, but
+    /// without requiring a specific name.
+    /// - Returns: A dictionary whose keys are the registrations' names and whose values are the
+    /// objects requested.
+    func resolveAll<T>(_ type: T.Type) -> [String?: T]
 }
 
 public extension Resolver {

--- a/Tests/DuplicateRegistrationTest.swift
+++ b/Tests/DuplicateRegistrationTest.swift
@@ -38,5 +38,17 @@ final class DuplicateRegistrationTest: BaseFactoryTest {
             Factory.shared.resolve(),
             "Expected later registration to override earlier one"
         )
+        
+        XCTAssertEqual(
+            [nil: "later"],
+            Factory.shared.resolveAll(String.self),
+            "Expected later registration to hide earlier one"
+        )
+        
+        XCTAssertEqual(
+            [nil: 2],
+            Factory.shared.resolveAll(Int.self),
+            "Expected later registration to hide earlier one"
+        )
     }
 }

--- a/Tests/RegistrationNameTests.swift
+++ b/Tests/RegistrationNameTests.swift
@@ -50,5 +50,12 @@ final class RegistrationNameTests: BaseFactoryTest {
             namedResolution,
             "Expected expliticly-named to be named '1' but saw registration \(namedResolution)"
         )
+        
+        // ensure resolveAll gets all of them
+        let allResolutions = Factory.shared.resolveAll(String.self)
+        XCTAssertEqual(
+            [nil: "unnamed", "1": "named 1", "2": "named 2"],
+            allResolutions
+        )
     }
 }


### PR DESCRIPTION
## Issue Link

Fixes #64

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-15

## Overview of Changes

This PR adds the resolveAll method as a requirement of Resolver, and an implementation of it in the factory.

### Anything you want to highlight?

This method could afford to be better-documented, but it's niche enough that I don't think it belongs in the sample apps. Contextless examples (like what currently exist for `Registration`, `MultitypeService`, etc) may not be particularly useful.

## Test Plan

See the docs and tests.