### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ formatting guidelines.
 
 ## Unreleased
 
+## [1.0.0] - 2022-12-13
+
 ### Removed
 
 - Dropped support for CocoaPods &lt; 1.11.3.
@@ -75,3 +77,4 @@ Initial release.
 [0.1.0]: https://github.com/Tiny-Home-Consulting/Dependiject/tree/0.1.0
 [0.2.0]: https://github.com/Tiny-Home-Consulting/Dependiject/tree/0.2.0
 [0.3.0]: https://github.com/Tiny-Home-Consulting/Dependiject/tree/0.3.0
+[1.0.0]: https://github.com/Tiny-Home-Consulting/Dependiject/tree/1.0.0

--- a/Dependiject.podspec
+++ b/Dependiject.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
     s.name = 'Dependiject'
-    s.version = '0.3.0'
+    s.version = '1.0.0'
     s.summary = 'Dependiject provides simple, flexible, and thread-safe dependency injection for testability and inversion of control in SwiftUI apps.'
     
     s.homepage = 'https://github.com/Tiny-Home-Consulting/Dependiject'

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ expects yarn to be installed globally.
 Add the following line to your Podfile:
 
 ```ruby
-pod 'Dependiject', '~> 0.3'
+pod 'Dependiject', '~> 1.0'
 ```
 
 ### Swift Package Manager
@@ -106,7 +106,7 @@ Add the following entry to the `dependencies` array in your Package.swift:
 ```swift
 .package(
     url: "https://github.com/Tiny-Home-Consulting/Dependiject.git",
-    .upToNextMajor(from: "0.3.0")
+    .upToNextMajor(from: "1.0.0")
 )
 ```
 

--- a/iOS 13 Example/Podfile.lock
+++ b/iOS 13 Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Dependiject (0.3.0)
+  - Dependiject (1.0.0)
   - MockingbirdFramework (0.20.0)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 5ae7d97714c3ab3a4ffe0a33e4f71a3e91966ea2
+  Dependiject: 19d9b890d0806d85f2f6156af97c789f0a77e8c9
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 8b19bacc7326bb5fa155fd0bbe689850b9a06311

--- a/iOS 14 Example/Podfile.lock
+++ b/iOS 14 Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Dependiject (0.3.0)
+  - Dependiject (1.0.0)
   - MockingbirdFramework (0.20.0)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Dependiject: 5ae7d97714c3ab3a4ffe0a33e4f71a3e91966ea2
+  Dependiject: 19d9b890d0806d85f2f6156af97c789f0a77e8c9
   MockingbirdFramework: 54e35fbbb47b806c1a1fae2cf3ef99f6eceb55e5
 
 PODFILE CHECKSUM: 36b8602ef54137bf035edec6b6d987f87e3dfa23


### PR DESCRIPTION
## Issue Link

N/A

## Overview of Changes

This PR bumps the version number from 0.3.0 to 1.0.0.

### Anything you want to highlight?

The link in the changelog will be a 404 for now; I'll add the proper tag once this is merged. I want the tag to point to the version of this commit that will be on master, not the one that is currently on this branch.

## Test Plan

N/A
