### PR TITLE
Restructure SingletonRegistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ formatting guidelines.
 
 ## Unreleased
 
+### Changed
+
+- Singleton registrations no longer hold onto the closure after the instance is created.
+
 ## [1.0.0] - 2022-12-13
 
 ### Removed

--- a/Dependiject/Util.swift
+++ b/Dependiject/Util.swift
@@ -1,0 +1,12 @@
+//
+//  Util.swift
+//  Dependiject
+//
+//  Created by William Baker on 12/14/2022.
+//  Copyright (c) 2022 Tiny Home Consulting LLC. All rights reserved.
+//
+
+internal enum CallbackOrInstance<T> {
+    case callback((Resolver) -> T)
+    case instance(T)
+}


### PR DESCRIPTION
## Issue Link

Fixes #76 

https://tinyhomeconsultingllc.atlassian.net/browse/THOS-22

## Overview of Changes

This PR restructures `SingletonRegistration` to release the closure once the object is instantiated.

### Anything you want to highlight?

N/A

## Test Plan

Run a sample app and wait for the first view (after the splash screen) to appear. Then, use the memory graph to ensure the `SingletonRegistration` does not hold a reference to a "Swift closure context".
