### PR TITLE
Create Synchronizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ formatting guidelines.
 
 ## Unreleased
 
+### Added
+
+- Added a `setSynchronizer` method to `Factory`, and a corresponding `Synchronizer` protocol, for
+  controlling how dependency resolution is synchronized.
+
 ### Changed
 
 - Singleton registrations no longer hold onto the closure after the instance is created.

--- a/Dependiject/Synchronization.swift
+++ b/Dependiject/Synchronization.swift
@@ -1,0 +1,46 @@
+//
+//  Synchronization.swift
+//
+//
+//  Created by Riley Baker on 9/5/24.
+//
+
+import Foundation
+
+/// A type that serializes work to prevent data races.
+public protocol Synchronizer {
+    /// Synchronize some work with other calls to this method.
+    ///
+    /// No two closures passed to this method may run at the same time. How this is achieved is up
+    /// to the implementation. For example, ``LockSynchronizer`` uses a recursive lock for
+    /// serialization without enforcing particulars about threads or executors.
+    ///
+    /// If you know that all dependencies will be resolved on the main thread, and want to enforce
+    /// this, you could write an implementation that calls
+    /// [`MainActor.assumeIsolated(_:file:line:)`](https://developer.apple.com/documentation/swift/mainactor/assumeisolated(_:file:line:)-swift.type.method)
+    /// or asserts
+    /// [`Thread.isMainThread`](https://developer.apple.com/documentation/foundation/thread/1412704-ismainthread),
+    /// for example.
+    ///
+    /// - Important: This method may be called recursively. Therefore, do not use a synchronization
+    /// construct that deadlocks if called recursively, such as `NSLock.withLock` or
+    /// `DispatchQueue.main.sync`.
+    @Sendable
+    func synchronize<T>(_ body: () throws -> T) rethrows -> T
+}
+
+/// A synchronizer that uses
+/// [`NSRecursiveLock`](https://developer.apple.com/documentation/foundation/nsrecursivelock)
+/// to ensure synchronization.
+public struct LockSynchronizer: Synchronizer, Sendable {
+    private let lock = NSRecursiveLock()
+    
+    @Sendable
+    public func synchronize<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return try body()
+    }
+}


### PR DESCRIPTION
## Issue Link

Fixes #79

## Overview of Changes

This PR adds `Synchronizer`, an implementation thereof, and a `setSynchronizer` method on Factory. I also changed the implementation of the Factory methods to reflect the new synchronization API.

### Anything you want to highlight?

`setSynchronizer` cannot be made thread-safe. Does the block comment inside of it adequately explain why? Is the documentation on it thorough enough?

## Test Plan

We already have synchronization tests in `ParallelResolutionTest`. Since the new default implementation is the same as the only implementation available before, no new tests are needed for that. Additionally, this PR does not add any other synchronization methods to Dependiject, so no tests for other synchronization methods are required.
